### PR TITLE
Add the friendlyPath argument to $Refs::_resolve

### DIFF
--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -97,7 +97,7 @@ function dereference$Ref ($ref, path, pathFromRoot, parents, $refs, options) {
   debug('Dereferencing $ref pointer "%s" at %s', $ref.$ref, path);
 
   var $refPath = url.resolve(path, $ref.$ref);
-  var pointer = $refs._resolve($refPath, options);
+  var pointer = $refs._resolve($refPath, options, $ref.$ref);
 
   // Check for circular references
   var directCircular = pointer.circular;

--- a/lib/refs.js
+++ b/lib/refs.js
@@ -140,19 +140,20 @@ $Refs.prototype._add = function (path) {
  *
  * @param {string} path - The path being resolved, optionally with a JSON pointer in the hash
  * @param {$RefParserOptions} [options]
+ * @param {string} [friendlyPath]
  * @returns {Pointer}
  * @protected
  */
-$Refs.prototype._resolve = function (path, options) {
+$Refs.prototype._resolve = function (path, options, friendlyPath) {
   var absPath = url.resolve(this._root$Ref.path, path);
   var withoutHash = url.stripHash(absPath);
   var $ref = this._$refs[withoutHash];
 
   if (!$ref) {
-    throw ono('Error resolving $ref pointer "%s". \n"%s" not found.', path, withoutHash);
+    throw ono('Error resolving $ref pointer "%s". \n"%s" not found.', friendlyPath || path, withoutHash);
   }
 
-  return $ref.resolve(absPath, options, path);
+  return $ref.resolve(absPath, options, friendlyPath || path);
 };
 
 /**


### PR DESCRIPTION
Unfortunately #75 wasn't enough to get everything back to how it worked in 3.x 😢 With this change the tests for apiaryio/fury-adapter-swagger#158 finally pass.

I don't know this library well enough to write a test for this change. Any pointer would be appreciated.