### PR TITLE
Ignore http and https, add url.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -24,9 +24,10 @@ module.exports = karmaConfig({
   sourceDir: "lib",
   fixtures: "test/fixtures/**/*.js",
   browsers: {
-    ie: true,
+    ie: false,
+    safari: false
   },
   config: {
-    exclude,
+    exclude
   }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -7706,8 +7706,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -9605,7 +9604,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -9614,8 +9612,7 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "browser": {
-    "fs": false
+    "fs": false,
+    "http": false,
+    "https": false
   },
   "files": [
     "lib"
@@ -70,6 +72,7 @@
   "dependencies": {
     "call-me-maybe": "^1.0.1",
     "js-yaml": "^3.13.1",
-    "ono": "^5.1.0"
+    "ono": "^5.1.0",
+    "url": "^0.11.0"
   }
 }


### PR DESCRIPTION
- Breaks all browser tests in Karma as they somehow resolve references by downloading schemas. I don't understand how this works, how is it possible that `http` is available in browser tests? Or is `karma` webserver somehow doing the requests on behalf of browser?
