### PR TITLE
support for nested references

### DIFF
--- a/lib/resolve-external.js
+++ b/lib/resolve-external.js
@@ -57,18 +57,14 @@ function crawl (obj, path, $refs, options) {
     if ($Ref.isExternal$Ref(obj)) {
       promises.push(resolve$Ref(obj, path, $refs, options));
     }
-    else {
-      for (let key of Object.keys(obj)) {
-        let keyPath = Pointer.join(path, key);
-        let value = obj[key];
+    for (let key of Object.keys(obj)) {
+      let keyPath = Pointer.join(path, key);
+      let value = obj[key];
 
-        if ($Ref.isExternal$Ref(value)) {
-          promises.push(resolve$Ref(value, keyPath, $refs, options));
-        }
-        else {
-          promises = promises.concat(crawl(value, keyPath, $refs, options));
-        }
+      if ($Ref.isExternal$Ref(value)) {
+        promises.push(resolve$Ref(value, keyPath, $refs, options));
       }
+      promises = promises.concat(crawl(value, keyPath, $refs, options));
     }
   }
 


### PR DESCRIPTION
This PR allows for nested references:
for example:
```
{
    "Nats": {
      "$ref": "common://nats",
      "RetryIntervalMs": {
        "$ref": "common://pool:PoolSize"
      }
    }
  }
```
  