### PR TITLE
Add path information to errors

### DIFF
--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -96,7 +96,13 @@ function dereference$Ref ($ref, path, pathFromRoot, parents, $refs, options) {
   // console.log('Dereferencing $ref pointer "%s" at %s', $ref.$ref, path);
 
   let $refPath = url.resolve(path, $ref.$ref);
-  let pointer = $refs._resolve($refPath, options);
+  let pointer;
+
+  try {
+    pointer = $refs._resolve($refPath, options);
+  } catch (e) {
+    throw ono(e, { path, originalPath: $ref.$ref });
+  }
 
   // Check for circular references
   let directCircular = pointer.circular;

--- a/lib/resolve-external.js
+++ b/lib/resolve-external.js
@@ -4,6 +4,7 @@ const $Ref = require("./ref");
 const Pointer = require("./pointer");
 const parse = require("./parse");
 const url = require("./util/url");
+const { ono } = require("ono");
 
 module.exports = resolveExternal;
 
@@ -100,8 +101,14 @@ async function resolve$Ref ($ref, path, $refs, options) {
     return Promise.resolve($ref.value);
   }
 
-  // Parse the $referenced file/url
-  const result = await parse(resolvedPath, $refs, options);
+  let result;
+
+  try {
+    // Parse the $referenced file/url
+    result = await parse(resolvedPath, $refs, options);
+  } catch (e) {
+    throw ono(e, { path: resolvedPath });
+  }
 
   // Crawl the parsed value
   // console.log('Resolving $ref pointers in %s', withoutHash);


### PR DESCRIPTION
Hey! This PR adds extra information to the errors triggered when dereferencing and resolving external references. The reason I'm adding this info is that in the [AsyncAPI playground](https://playground.asyncapi.io), I want to find line and column of the failing $ref and with the current error I'd have to parse the error message, which is not ideal.

I suspect this info could be added to other errors too so feel free to point me out to the other places and I'll be happy to add them on this PR.

Thanks a lot for the excellent tool 🙌 