### PR TITLE
Handle direct external circular references

### DIFF
--- a/lib/pointer.js
+++ b/lib/pointer.js
@@ -64,6 +64,7 @@ function Pointer ($ref, path, friendlyPath) {
  *
  * @param {*} obj - The object that will be crawled
  * @param {$RefParserOptions} options
+ * @param {string} pathFromRoot - the path of place that initiated resolving
  *
  * @returns {Pointer}
  * Returns a JSON pointer whose {@link Pointer#value} is the resolved value.
@@ -71,7 +72,7 @@ function Pointer ($ref, path, friendlyPath) {
  * the {@link Pointer#$ref} and {@link Pointer#path} will reflect the resolution path
  * of the resolved value.
  */
-Pointer.prototype.resolve = function (obj, options) {
+Pointer.prototype.resolve = function (obj, options, pathFromRoot) {
   let tokens = Pointer.parse(this.path, this.originalPath);
 
   // Crawl the object, one token at a time
@@ -81,6 +82,10 @@ Pointer.prototype.resolve = function (obj, options) {
     if (resolveIf$Ref(this, options)) {
       // The $ref path has changed, so append the remaining tokens to the path
       this.path = Pointer.join(this.path, tokens.slice(i));
+    }
+
+    if (typeof this.value === "object" && this.value !== null && "$ref" in this.value) {
+      return this;
     }
 
     let token = tokens[i];
@@ -94,7 +99,10 @@ Pointer.prototype.resolve = function (obj, options) {
   }
 
   // Resolve the final value
-  resolveIf$Ref(this, options);
+  if (!this.value || this.value.$ref && url.resolve(this.path, this.value.$ref) !== pathFromRoot) {
+    resolveIf$Ref(this, options);
+  }
+
   return this;
 };
 
@@ -226,7 +234,7 @@ function resolveIf$Ref (pointer, options) {
       pointer.circular = true;
     }
     else {
-      let resolved = pointer.$ref.$refs._resolve($refPath, url.getHash(pointer.path), options);
+      let resolved = pointer.$ref.$refs._resolve($refPath, pointer.path, options);
       pointer.indirections += resolved.indirections + 1;
 
       if ($Ref.isExtended$Ref(pointer.value)) {

--- a/lib/ref.js
+++ b/lib/ref.js
@@ -112,7 +112,7 @@ $Ref.prototype.get = function (path, options) {
 $Ref.prototype.resolve = function (path, options, friendlyPath, pathFromRoot) {
   let pointer = new Pointer(this, path, friendlyPath);
   try {
-    return pointer.resolve(this.value, options);
+    return pointer.resolve(this.value, options, pathFromRoot);
   }
   catch (err) {
     if (!options || !options.continueOnError || !isHandledError(err)) {

--- a/test/specs/circular-external-direct/circular-external-direct-child.yaml
+++ b/test/specs/circular-external-direct/circular-external-direct-child.yaml
@@ -1,0 +1,2 @@
+foo:
+  $ref: ./circular-external-direct-root.yaml#/foo

--- a/test/specs/circular-external-direct/circular-external-direct-root.yaml
+++ b/test/specs/circular-external-direct/circular-external-direct-root.yaml
@@ -1,0 +1,1 @@
+$ref: ./circular-external-direct-child.yaml#/foo

--- a/test/specs/circular-external-direct/circular-external-direct.spec.js
+++ b/test/specs/circular-external-direct/circular-external-direct.spec.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const chai = require("chai");
+const chaiSubset = require("chai-subset");
+chai.use(chaiSubset);
+const { expect } = chai;
+const $RefParser = require("../../../lib");
+const path = require("../../utils/path");
+const parsedSchema = require("./parsed");
+const dereferencedSchema = require("./dereferenced");
+
+describe("Schema with direct circular (recursive) external $refs", () => {
+  it("should parse successfully", async () => {
+    let parser = new $RefParser();
+    const schema = await parser.parse(path.rel("specs/circular-external-direct/circular-external-direct-root.yaml"));
+    expect(schema).to.equal(parser.schema);
+    expect(schema).to.deep.equal(parsedSchema.schema);
+    expect(parser.$refs.paths()).to.deep.equal([path.abs("specs/circular-external-direct/circular-external-direct-root.yaml")]);
+    // The "circular" flag should NOT be set
+    // (it only gets set by `dereference`)
+    expect(parser.$refs.circular).to.equal(false);
+  });
+
+  it("should dereference successfully", async () => {
+    let parser = new $RefParser();
+    const schema = await parser.dereference(path.rel("specs/circular-external-direct/circular-external-direct-root.yaml"));
+    expect(schema).to.equal(parser.schema);
+    expect(schema).to.deep.equal(dereferencedSchema);
+    // The "circular" flag should be set
+    expect(parser.$refs.circular).to.equal(true);
+  });
+});

--- a/test/specs/circular-external-direct/dereferenced.js
+++ b/test/specs/circular-external-direct/dereferenced.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports =
+  {
+    $ref: "./circular-external-direct-root.yaml#/foo",
+  };

--- a/test/specs/circular-external-direct/parsed.js
+++ b/test/specs/circular-external-direct/parsed.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports =
+{
+  schema: {
+    $ref: "./circular-external-direct-child.yaml#/foo",
+  },
+};

--- a/test/specs/circular-external/dereferenced.js
+++ b/test/specs/circular-external/dereferenced.js
@@ -25,7 +25,7 @@ const dereferencedSchema = module.exports =
       },
     },
     thing: {
-      $ref: "#/definitions/thing"
+      $ref: "circular-external.yaml#/definitions/thing"
     },
     person: {
       title: "person",


### PR DESCRIPTION
Should fix_ https://github.com/APIDevTools/json-schema-ref-parser/issues/180

Currently json-schema-ref-parser fails to process the document and errors out.
![image](https://user-images.githubusercontent.com/9273484/80421154-4df05480-88dc-11ea-9d20-691fc6faf437.png)

I'm not fully convinced about the fix though, think there might be some slightly nicer way to accomplish the same result?