### PR TITLE
Throw when no plugin returned a result

### DIFF
--- a/lib/util/plugins.js
+++ b/lib/util/plugins.js
@@ -84,7 +84,9 @@ exports.run = function (plugins, method, file, $refs) {
           // A synchronous result was returned
           onSuccess(result);
         }
-        // else { the callback will be called }
+        else if (index === plugins.length) {
+          throw new Error("No promise has been returned or callback has been called.");
+        }
       }
       catch (e) {
         onError(e);

--- a/test/specs/parsers/parsers.spec.js
+++ b/test/specs/parsers/parsers.spec.js
@@ -68,7 +68,7 @@ describe("References to non-JSON files", () => {
     expect(schema).to.deep.equal(dereferencedSchema.binaryParser);
   });
 
-  it("should throw an error if no no parser can be matched", async () => {
+  it("should throw an error if no parser can be matched", async () => {
     try {
       await $RefParser.dereference(path.rel("specs/parsers/parsers.yaml"), {
         parse: {
@@ -78,11 +78,35 @@ describe("References to non-JSON files", () => {
           binary: false,
         },
       });
+      helper.shouldNotGetCalled();
     }
     catch (err) {
       expect(err).to.be.an.instanceOf(SyntaxError);
       expect(err.message).to.contain("Unable to parse ");
       expect(err.message).to.contain("parsers/parsers.yaml");
+    }
+  });
+
+  it("should throw an error if no parser returned a result", async () => {
+    try {
+      await $RefParser.dereference(path.rel("specs/parsers/parsers.yaml"), {
+        parse: {
+          yaml: {
+            canParse: true,
+            parse () {
+            }
+          },
+          json: false,
+          text: false,
+          binary: false,
+        },
+      });
+      helper.shouldNotGetCalled();
+    }
+    catch (err) {
+      // would time out otherwise
+      expect(err).to.be.an.instanceOf(ParserError);
+      expect(err.message).to.contain("No promise has been returned or callback has been called.");
     }
   });
 

--- a/test/specs/resolvers/resolvers.spec.js
+++ b/test/specs/resolvers/resolvers.spec.js
@@ -137,6 +137,28 @@ describe("options.resolve", () => {
     }
   });
 
+  it("should throw an error if no resolver returned a result", async () => {
+    try {
+      await $RefParser.dereference(path.rel("specs/resolvers/resolvers.yaml"), {
+        resolve: {
+          http: false,
+          file: {
+            order: 1,
+            canRead: true,
+            read () {
+
+            }
+          }
+        }
+      });
+      helper.shouldNotGetCalled();
+    }
+    catch (err) {
+      // would time out otherwise
+      expect(err).to.be.an.instanceOf(ResolverError);
+    }
+  });
+
   it("should throw a grouped error if no resolver can be matched and fastFail is false", async () => {
     const parser = new $RefParser();
     try {


### PR DESCRIPTION
A small condition making sure each plugin (parser or resolver) actually either called a callback or returned a promise.
Currently, if you use a customs resolvers or parsers and you forget to return the promise or invoke the callback, the promise returned by [run](https://github.com/APIDevTools/json-schema-ref-parser/blob/master/lib/util/plugins.js#L66) function is never resolved leading to a abrupt node process exit.