### PR TITLE
Resolved might be null

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -408,11 +408,12 @@ declare namespace $RefParser {
   export type JSONParserErrorType = "EUNKNOWN" | "EPARSER" | "EUNMATCHEDPARSER" | "ERESOLVER" | "EUNMATCHEDRESOLVER" | "EMISSINGPOINTER" | "EINVALIDPOINTER";
 
   export class JSONParserError extends Error {
+    constructor(message: string, source: string);
+
     readonly name: string;
     readonly message: string;
     readonly source: string;
     readonly path: Array<string | number>;
-    readonly errors: string;
     readonly code: JSONParserErrorType;
   }
 
@@ -438,27 +439,39 @@ declare namespace $RefParser {
   }
 
   export class ParserError extends JSONParserError {
+    constructor(message: string, source: string);
+
     readonly name = "ParserError";
     readonly code = "EPARSER";
   }
   export class UnmatchedParserError extends JSONParserError {
+    constructor(source: string);
+
     readonly name = "UnmatchedParserError";
     readonly code ="EUNMATCHEDPARSER";
   }
   export class ResolverError extends JSONParserError {
+    constructor(ex: Error | NodeJS.ErrnoException, source: string);
+
     readonly name = "ResolverError";
     readonly code ="ERESOLVER";
     readonly ioErrorCode?: string;
   }
   export class UnmatchedResolverError extends JSONParserError {
+    constructor(source: string);
+
     readonly name = "UnmatchedResolverError";
     readonly code ="EUNMATCHEDRESOLVER";
   }
   export class MissingPointerError extends JSONParserError {
+    constructor(token: string | number, source: string);
+
     readonly name = "MissingPointerError";
     readonly code ="EMISSINGPOINTER";
   }
   export class InvalidPointerError extends JSONParserError {
+    constructor(pointer: string, source: string);
+
     readonly name = "InvalidPointerError";
     readonly code ="EINVALIDPOINTER";
   }

--- a/lib/pointer.js
+++ b/lib/pointer.js
@@ -227,6 +227,10 @@ function resolveIf$Ref (pointer, options) {
     }
     else {
       let resolved = pointer.$ref.$refs._resolve($refPath, url.getHash(pointer.path), options);
+      if (resolved === null) {
+        return false;
+      }
+
       pointer.indirections += resolved.indirections + 1;
 
       if ($Ref.isExtended$Ref(pointer.value)) {

--- a/lib/ref.js
+++ b/lib/ref.js
@@ -53,7 +53,7 @@ function $Ref () {
 /**
  * Pushes an error to errors array.
  *
- * @param {Array<JSONParserError | JSONParserErrorGroup>} error - The error to be pushed
+ * @param {Array<JSONParserError | JSONParserErrorGroup>} err - The error to be pushed
  * @returns {void}
  */
 $Ref.prototype.addError = function (err) {
@@ -61,16 +61,21 @@ $Ref.prototype.addError = function (err) {
     this.errors = [];
   }
 
+  const existingErrors = this.errors.map(({ footprint }) => footprint);
+
   // the path has been almost certainly set at this point,
-  // but just in case something went wrong, let's inject path if necessary
+  // but just in case something went wrong, normalizeError injects path if necessary
+  // moreover, certain errors might point at the same spot, so filter them out to reduce noise
   if (Array.isArray(err.errors)) {
-    this.errors.push(...err.errors.map(normalizeError));
+    this.errors.push(...err.errors
+      .map(normalizeError)
+      .filter(({ footprint }) => !existingErrors.includes(footprint)),
+    );
   }
-  else {
+  else if (!existingErrors.includes(err.footprint)) {
     this.errors.push(normalizeError(err));
   }
 };
-
 
 /**
  * Determines whether the given JSON reference exists within this {@link $Ref#value}.
@@ -107,7 +112,7 @@ $Ref.prototype.get = function (path, options) {
  * @param {$RefParserOptions} options
  * @param {string} friendlyPath - The original user-specified path (used for error messages)
 *  @param {string} pathFromRoot - The path of `obj` from the schema root
- * @returns {Pointer}
+ * @returns {Pointer | null}
  */
 $Ref.prototype.resolve = function (path, options, friendlyPath, pathFromRoot) {
   let pointer = new Pointer(this, path, friendlyPath);

--- a/lib/util/errors.js
+++ b/lib/util/errors.js
@@ -15,6 +15,10 @@ const JSONParserError = exports.JSONParserError = class JSONParserError extends 
 
     Ono.extend(this);
   }
+
+  get footprint () {
+    return `${this.path}+${this.source}+${this.code}+${this.message}`;
+  }
 };
 
 setErrorName(JSONParserError);

--- a/test/specs/missing-pointers/external-from-internal.yaml
+++ b/test/specs/missing-pointers/external-from-internal.yaml
@@ -1,0 +1,5 @@
+internal1:
+  $ref: '#/internal2'
+internal2:
+  $ref: '#/external'
+

--- a/test/specs/missing-pointers/missing-pointers.spec.js
+++ b/test/specs/missing-pointers/missing-pointers.spec.js
@@ -21,25 +21,65 @@ describe("Schema with missing pointers", () => {
     }
   });
 
-  it("should throw a grouped error for missing pointer if continueOnError is true", async () => {
-    const parser = new $RefParser();
+  it("should throw an error for missing pointer in external file", async () => {
     try {
-      await parser.dereference({ foo: { $ref: "#/baz" }}, { continueOnError: true });
+      await $RefParser.dereference({ foo: { $ref: path.abs("specs/missing-pointers/external-from-internal.yaml") }});
       helper.shouldNotGetCalled();
     }
     catch (err) {
-      expect(err).to.be.instanceof(JSONParserErrorGroup);
-      expect(err.files).to.equal(parser);
-      expect(err.files.$refs._root$Ref.value).to.deep.equal({ foo: null });
-      expect(err.message).to.have.string("1 error occurred while reading '");
-      expect(err.errors).to.containSubset([
-        {
-          name: MissingPointerError.name,
-          message: "Token \"baz\" does not exist.",
-          path: ["foo"],
-          source: message => message.endsWith("/test/") || message.startsWith("http://localhost"),
-        }
-      ]);
+      expect(err).to.be.an.instanceOf(MissingPointerError);
+      expect(err.message).to.contain("Token \"external\" does not exist.");
     }
+  });
+
+  context("when continueOnError is true", () => {
+    it("should throw a grouped error for missing pointer", async () => {
+      const parser = new $RefParser();
+      try {
+        await parser.dereference({ foo: { $ref: "#/baz" }}, { continueOnError: true });
+        helper.shouldNotGetCalled();
+      }
+      catch (err) {
+        expect(err).to.be.instanceof(JSONParserErrorGroup);
+        expect(err.files).to.equal(parser);
+        expect(err.files.$refs._root$Ref.value).to.deep.equal({ foo: null });
+        expect(err.message).to.have.string("1 error occurred while reading '");
+        expect(err.errors).to.containSubset([
+          {
+            name: MissingPointerError.name,
+            message: "Token \"baz\" does not exist.",
+            path: ["foo"],
+            source: message => message.endsWith("/test/") || message.startsWith("http://localhost"),
+          }
+        ]);
+      }
+    });
+
+    it("should throw an error for missing pointer in external file", async () => {
+      const parser = new $RefParser();
+      try {
+        await parser.dereference({ foo: { $ref: path.abs("specs/missing-pointers/external-from-internal.yaml") }}, { continueOnError: true });
+        helper.shouldNotGetCalled();
+      }
+      catch (err) {
+        expect(err).to.be.instanceof(JSONParserErrorGroup);
+        expect(err.files).to.equal(parser);
+        expect(err.files.$refs._root$Ref.value).to.deep.equal({
+          foo: {
+            internal1: null,
+            internal2: null,
+          }
+        });
+        expect(err.message).to.have.string("1 error occurred while reading '");
+        expect(err.errors).to.containSubset([
+          {
+            name: MissingPointerError.name,
+            message: "Token \"external\" does not exist.",
+            path: ["internal2"],
+            source: message => message.endsWith("missing-pointers/external-from-internal.yaml") || message.startsWith("http://localhost"),
+          }
+        ]);
+      }
+    });
   });
 });


### PR DESCRIPTION
Fixes #161.

A small oversight - $Ref.resolve may [return null](https://github.com/APIDevTools/json-schema-ref-parser/blob/master/lib/ref.js#L122) now, so we need to take that into account.
Depends on https://github.com/APIDevTools/json-schema-ref-parser/pull/167 hence leaving it in adraft state.

Last but not least - typed constructors, just in case someone decides to throw these errors in parser or resolver, etc.

