### PR TITLE
Unixify paths in tests

### DIFF
--- a/test/specs/error-source/error-source.spec.js
+++ b/test/specs/error-source/error-source.spec.js
@@ -38,7 +38,7 @@ describe("Report correct error source and path for", () => {
       expect(err.errors).to.containSubset([
         {
           name: ResolverError.name,
-          source: path.abs("specs/error-source/broken-external.json"),
+          source: path.unixify(path.abs("specs/error-source/broken-external.json")),
           path: ["components", "schemas", "testSchema", "properties", "test"],
           message: message => typeof message === "string",
         },
@@ -56,13 +56,13 @@ describe("Report correct error source and path for", () => {
       expect(err.errors).to.containSubset([
         {
           name: MissingPointerError.name,
-          source: path.abs("specs/error-source/invalid-external.json"),
+          source: path.unixify(path.abs("specs/error-source/invalid-external.json")),
           path: ["foo", "bar"],
           message: message => typeof message === "string",
         },
         {
           name: ResolverError.name,
-          source: path.abs("specs/error-source/broken-external.json"),
+          source: path.unixify(path.abs("specs/error-source/broken-external.json")),
           path: ["components", "schemas", "testSchema", "properties", "test"],
           message: message => typeof message === "string",
         },
@@ -80,7 +80,7 @@ describe("Report correct error source and path for", () => {
       expect(err.errors).to.containSubset([
         {
           name: InvalidPointerError.name,
-          source: path.abs("specs/error-source/invalid-pointer.json"),
+          source: path.unixify(path.abs("specs/error-source/invalid-pointer.json")),
           path: ["foo", "baz"],
           message: message => typeof message === "string",
         },

--- a/test/specs/invalid-pointers/invalid-pointers.js
+++ b/test/specs/invalid-pointers/invalid-pointers.js
@@ -36,7 +36,7 @@ describe("Schema with invalid pointers", () => {
           name: InvalidPointerError.name,
           message: "Invalid $ref pointer \"f\". Pointers must begin with \"#/\"",
           path: ["foo"],
-          source: path.abs("specs/invalid-pointers/invalid.json"),
+          source: path.unixify(path.abs("specs/invalid-pointers/invalid.json")),
         }
       ]);
     }

--- a/test/utils/path.js
+++ b/test/utils/path.js
@@ -37,6 +37,13 @@ function filesystemPathHelpers () {
     },
 
     /**
+     * Returns the path with normalized, UNIX-like, slashes. Disk letter is lower-cased, if present.
+     */
+    unixify (file) {
+      return file.replace(/\\/g, "/").replace(/^[A-Z](?=:\/)/, (letter) => letter.toLowerCase());
+    },
+
+    /**
      * Returns the path of a file in the "test" directory as a URL.
      * (e.g. "file://path/to/json-schema-ref-parser/test/files...")
      */
@@ -111,6 +118,12 @@ function urlPathHelpers () {
       return testsDir + encodePath(file);
     },
 
+    /**
+     * Does nothing. Needed to comply with Filesystem path helpers.
+     */
+    unixify (file) {
+      return file;
+    },
     /**
      * Returns the path of a file in the "test" directory as an absolute URL.
      * (e.g. "http://localhost/test/files/...")


### PR DESCRIPTION
Followup PR of https://github.com/APIDevTools/json-schema-ref-parser/pull/167.

Error sources are UNIX-like filepaths, therefore slashes differ.