### PR TITLE
fix: do not re-crawl unless necessary

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -135,7 +135,9 @@ function inventory$Ref ($refParent, $refKey, path, pathFromRoot, indirections, i
   });
 
   // Recursively crawl the resolved value
-  crawl(pointer.value, null, pointer.path, pathFromRoot, indirections + 1, inventory, $refs, options);
+  if (!existingEntry) {
+    crawl(pointer.value, null, pointer.path, pathFromRoot, indirections + 1, inventory, $refs, options);
+  }
 }
 
 /**


### PR DESCRIPTION
Related to the indirect refs bundle optimization: https://github.com/APIDevTools/json-schema-ref-parser/pull/62

For large specifications, the current implementation ends up re-crawling a LOT. So much so that for one customer's spec (which is 48k lines, with inline $refs only, no remote ones), it takes around 20s to bundle. 

<img width="1402" alt="Screen Shot 2020-06-05 at 6 47 24 PM" src="https://user-images.githubusercontent.com/847542/83930610-1b990900-a75e-11ea-954e-5852eed1f617.png">

After a brief investigation, it seems like we might not need to re-crawl if we're just updating the inventoried $ref to be a more direct one?

The tests still pass, but I'm not 100% sure on this and so would appreciate some 👀.

For the specification in question, here's the before and after:

<img width="630" alt="Screen Shot 2020-06-05 at 6 47 53 PM" src="https://user-images.githubusercontent.com/847542/83930605-1340ce00-a75e-11ea-9073-c73671a68d6f.png">

So basically an over 20x increase in performance!
