### PR TITLE
Fixes treating empty parsing results

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -124,7 +124,7 @@ function parseFile (file, options, $refs) {
       .then(onParsed, onError);
 
     function onParsed (parser) {
-      if ((options.continueOnError || !parser.plugin.allowEmpty) && isEmpty(parser.result)) {
+      if (!parser.plugin.allowEmpty && isEmpty(parser.result)) {
         reject(ono.syntax(`Error parsing "${file.url}" as ${parser.plugin.name}. \nParsed value is empty`));
       }
       else {

--- a/test/specs/parsers/parsers.spec.js
+++ b/test/specs/parsers/parsers.spec.js
@@ -230,7 +230,7 @@ describe("References to non-JSON files", () => {
     }
   });
 
-  it("should throw a grouped error if no parser can be matched and fastFail is false", async () => {
+  it("should throw a grouped error if no parser can be matched and continueOnError is true", async () => {
     try {
       const parser = new $RefParser();
       await parser.dereference(path.rel("specs/parsers/parsers.yaml"), {

--- a/test/specs/resolvers/resolvers.spec.js
+++ b/test/specs/resolvers/resolvers.spec.js
@@ -159,7 +159,7 @@ describe("options.resolve", () => {
     }
   });
 
-  it("should throw a grouped error if no resolver can be matched and fastFail is false", async () => {
+  it("should throw a grouped error if no resolver can be matched and continueOnError is true", async () => {
     const parser = new $RefParser();
     try {
       await parser.dereference(path.abs("specs/resolvers/resolvers.yaml"), {


### PR DESCRIPTION
This PR fixes the condition of rejecting empty parsing results.

Currently, when `options.continueOnError` is true and result is empty it will reject.
With this change, it will reject only if `allowEmpty` is false. 

I'm a bit unsure whether this should be still dependent on `continueOnError`.