### PR TITLE
Skip typed arrays and DataViews while crawling the schema

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -39,7 +39,7 @@ function bundle (parser, options) {
 function crawl (parent, key, path, pathFromRoot, indirections, inventory, $refs, options) {
   let obj = key === null ? parent : parent[key];
 
-  if (obj && typeof obj === "object") {
+  if (obj && typeof obj === "object" && !ArrayBuffer.isView(obj)) {
     if ($Ref.isAllowed$Ref(obj)) {
       inventory$Ref(parent, key, path, pathFromRoot, indirections, inventory, $refs, options);
     }

--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -39,7 +39,7 @@ function crawl (obj, path, pathFromRoot, parents, $refs, options) {
     circular: false
   };
 
-  if (obj && typeof obj === "object") {
+  if (obj && typeof obj === "object" && !ArrayBuffer.isView(obj)) {
     parents.push(obj);
 
     if ($Ref.isAllowed$Ref(obj, options)) {

--- a/lib/resolve-external.js
+++ b/lib/resolve-external.js
@@ -54,7 +54,7 @@ function resolveExternal (parser, options) {
 function crawl (obj, path, $refs, options) {
   let promises = [];
 
-  if (obj && typeof obj === "object") {
+  if (obj && typeof obj === "object" && !ArrayBuffer.isView(obj)) {
     if ($Ref.isExternal$Ref(obj)) {
       promises.push(resolve$Ref(obj, path, $refs, options));
     }


### PR DESCRIPTION
This PR addresses the issue outlined in #185: when a schema contains typed arrays or DataViews, this part can safely be skipped during crawling because it cannot contain references.

This PR is marked as a draft because I couldn't figure out how to add tests for this. Initially I wanted to solve this with `chai-spies` such that a spy logs all the paths that the crawler crawled and checks whether the items of typed arrays are excluded from the crawl, but I could not add a spy on the crawler function as it is internal. Any help would be appreciated.

All the existing tests pass, except the HTTP-based ones which fail for a reason unrelated to the PR. Feel free to merge if you think that it is not required to add test cases to cover the changes in this PR.