### PR TITLE
Add path token to resolved pointer value

### DIFF
--- a/lib/pointer.js
+++ b/lib/pointer.js
@@ -73,6 +73,7 @@ function Pointer ($ref, path, friendlyPath) {
  */
 Pointer.prototype.resolve = function (obj, options) {
   let tokens = Pointer.parse(this.path, this.originalPath);
+  let token;
 
   // Crawl the object, one token at a time
   this.value = unwrapOrThrow(obj);
@@ -83,13 +84,14 @@ Pointer.prototype.resolve = function (obj, options) {
       this.path = Pointer.join(this.path, tokens.slice(i));
     }
 
-    let token = tokens[i];
+    token = tokens[i];
     if (this.value[token] === undefined || this.value[token] === null) {
       this.value = null;
       throw new MissingPointerError(token, this.originalPath);
     }
     else {
       this.value = this.value[token];
+      this.value.token = token;
     }
   }
 


### PR DESCRIPTION
When dereferencing a json schema, the `#/definitions` are merged into the root type.
As a result, when using json-schema-to-typescript to generate declaration files from the schema,
all externally referenced interfaces get merged into one big interface.
See: https://github.com/bcherny/json-schema-to-typescript/issues/143

By sticking the token to the resolved pointer value, the information about the path (i.e. the interface name) is not lost
and can be used to generate the right interfaces. The corresponding change can be found here:
https://github.com/nkappler/json-schema-to-typescript/commit/d53af1210d1514cf5b3e03723e4a24d02f065e73

*I am not sure if this is the 'proper' way to do it, but it is a tiny and simple fix and it works*