### PR TITLE
Do not mutate objects when values do not change

### DIFF
--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -57,13 +57,19 @@ function crawl (obj, path, pathFromRoot, parents, $refs, options) {
         if ($Ref.isAllowed$Ref(value, options)) {
           dereferenced = dereference$Ref(value, keyPath, keyPathFromRoot, parents, $refs, options);
           circular = dereferenced.circular;
-          obj[key] = dereferenced.value;
+          // Avoid pointless mutations; breaks frozen objects to no profit
+          if (obj[key] !== dereferenced.value) {
+            obj[key] = dereferenced.value;
+          }
         }
         else {
           if (parents.indexOf(value) === -1) {
             dereferenced = crawl(value, keyPath, keyPathFromRoot, parents, $refs, options);
             circular = dereferenced.circular;
-            obj[key] = dereferenced.value;
+            // Avoid pointless mutations; breaks frozen objects to no profit
+            if (obj[key] !== dereferenced.value) {
+              obj[key] = dereferenced.value;
+            }
           }
           else {
             circular = foundCircularReference(keyPath, $refs, options);


### PR DESCRIPTION
I had some code break in unexpected ways when ref-parser mutated my schemata (my fault—it doesn’t say it won’t), and deep-froze my inputs to catch it. I then discovered that ref-parser sometimes performs mutations on objects *even when the values do not change*. I suppose frozen schema objects may not be a super common use case, but it seems like a silly thing to break over: the equivalent of `obj[key] = obj[key]` after all does nothing *except* to break if `obj` is frozen.