### PR TITLE
add stripQuery method and strip the query from the extension

### DIFF
--- a/lib/util/url.js
+++ b/lib/util/url.js
@@ -69,9 +69,23 @@ exports.getProtocol = function getProtocol (path) {
 exports.getExtension = function getExtension (path) {
   let lastDot = path.lastIndexOf(".");
   if (lastDot >= 0) {
-    return path.substr(lastDot).toLowerCase();
+    return url.stripQuery(path.substr(lastDot).toLowerCase());
   }
   return "";
+};
+
+/**
+ * Removes the query, if any, from the given path.
+ *
+ * @param   {string} path
+ * @returns {string}
+ */
+exports.stripQuery = function stripQuery (path) {
+  let queryIndex = path.indexOf("?");
+  if (queryIndex >= 0) {
+    path = path.substr(0, queryIndex);
+  }
+  return path;
 };
 
 /**

--- a/test/specs/util/url.spec.js
+++ b/test/specs/util/url.spec.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const chai = require("chai");
+const chaiSubset = require("chai-subset");
+chai.use(chaiSubset);
+const { expect } = chai;
+const $url = require("../../../lib/util/url");
+
+describe("Return the extension of a URL", () => {
+  it("should return an empty string if there isn't any extension", async () => {
+    const extension = $url.getExtension("/file");
+    expect(extension).to.equal("");
+  });
+
+  it("should return the extension in lowercase", async () => {
+    const extension = $url.getExtension("/file.YML");
+    expect(extension).to.equal(".yml");
+  });
+
+  it("should return the extension without the query", async () => {
+    const extension = $url.getExtension("/file.yml?foo=bar");
+    expect(extension).to.equal(".yml");
+  });
+});


### PR DESCRIPTION
Given a url `https://example.com/file.yml?foo=bar`, the extension will be parsed as `.yml?foo=bar` and the relevant parsers will miss it.

This PR fixes this issue by stripping the query from the extension.