### PR TITLE
fix: request the schema id URL instead of the current page url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,6 +98,14 @@ $RefParser.prototype.parse = async function parse (path, schema, options, callba
     args.path = url.fromFileSystemPath(args.path);
     pathType = "file";
   }
+  else if (!args.path && args.schema && args.schema.$id) {
+    // when schema id has defined an URL should use that hostname to request the references,
+    // instead of using the current page URL
+    const params = url.parse(args.schema.$id);
+    const port = params.protocol === "https:" ? 443 : 80;
+
+    args.path = `${params.protocol}//${params.hostname}:${port}`;
+  }
 
   // Resolve the absolute path of the schema
   args.path = url.resolve(url.cwd(), args.path);


### PR DESCRIPTION
 **When the schema id is defined with an URL should use that hostname to request the references, instead of using the current page URL**

EXAMPLE: 

```json
{
	"$schema": "http://json-schema.org/draft-07/schema#",
	"$id": "https://resourse.example.com/schemas/resources/main.json#",
	"title": "This is my main schema",
	"description": "This is my main schema description.",
        "type": "object",
	"properties": {
	  "$ref": "/schemas/resources/version1.0.1.json#"
	}
  }
```

Currently, if the dereference work is being done locally at http://localhost:3000 the deref request will be done with URL  http://localhost:3000/schemas/resources/version.1.0.1.json instead of https://resourse.example.com/schemas/resources/version1.0.1.json

This is related to this [issue]( https://github.com/APIDevTools/json-schema-ref-parser/issues/29)
