### PR TITLE
Fix typescript type to allow disabling resolvers

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -208,7 +208,7 @@ declare namespace $RefParser {
       file?: Partial<ResolverOptions> | boolean;
       http?: HTTPResolverOptions | boolean;
     } & {
-      [key: string]: Partial<ResolverOptions>;
+      [key: string]: Partial<ResolverOptions> | boolean;
     };
 
     /**


### PR DESCRIPTION
Currently you can't pass a boolean as it doesn't match the maps type.