### PR TITLE
exception when `options` is undefined

### DIFF
--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -191,7 +191,7 @@ function dereference$Ref ($ref, path, pathFromRoot, parents, processedObjects, d
  */
 function foundCircularReference (keyPath, $refs, options) {
   $refs.circular = true;
-  if (!options.dereference.circular) {
+  if (options && options.dereference && !options.dereference.circular) {
     throw ono.reference(`Circular $ref pointer found at ${keyPath}`);
   }
   return true;


### PR DESCRIPTION
When I am trying to parse https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json -> `options` on this line is undefined and an exception occurs.