### PR TITLE
[rereference] add new method rereference (opposite of dereference)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Classes & Methods
 - [`$refs` property](ref-parser.md#refs)
 - [`dereference()` method](ref-parser.md#dereferenceschema-options-callback)
 - [`bundle()` method](ref-parser.md#bundleschema-options-callback)
+- [`rereference()` method](ref-parser.md#rereferenceschema-options)
 - [`parse()` method](ref-parser.md#parseschema-options-callback)
 - [`resolve()` method](ref-parser.md#resolveschema-options-callback)
 

--- a/docs/ref-parser.md
+++ b/docs/ref-parser.md
@@ -10,11 +10,12 @@ This is the default export of JSON Schema $Ref Parser.  You can creates instance
 ##### Methods
 - [`dereference()`](#dereferenceschema-options-callback)
 - [`bundle()`](#bundleschema-options-callback)
+- [`rereference()`](#rereferenceschema-options)
 - [`parse()`](#parseschema-options-callback)
 - [`resolve()`](#resolveschema-options-callback)
 
 ### `schema`
-The `schema` property is the parsed/bundled/dereferenced JSON Schema object.  This is the same value that is passed to the callback function (or Promise) when calling the [`parse`](#parseschema-options-callback), [`bundle`](#bundleschema-options-callback), or [`dereference`](#dereferenceschema-options-callback) methods.
+The `schema` property is the parsed/bundled/dereferenced/rereferenced JSON Schema object.  This is the same value that is passed to the callback function (or Promise) when calling the [`parse`](#parseschema-options-callback), [`bundle`](#bundleschema-options-callback), or [`dereference`](#dereferenceschema-options-callback) methods.
 
 ```javascript
 let parser = new $RefParser();
@@ -96,6 +97,29 @@ let schema = await $RefParser.bundle("my-schema.yaml");
 console.log(schema.definitions.person); // => {$ref: "#/definitions/schemas~1people~1Bruce-Wayne.json"}
 ```
 
+
+### `rereference(schema, [options])`
+
+- **schema** (_required_) - `object`<br>
+  A JSON Schema object.  See the [`parse`](#parseschema-options-callback) method for more info.
+
+- **options** (_optional_) - `object`<br>
+  See [options](options.md) for the full list of options
+
+- **Return Value:** `object`<br>
+  A JSON Schema object.
+
+Rereferences all `$ref` pointers in the JSON Schema, replacing each JavaScript circular pointers with its new reference. This results in a schema object that does can contain `$ref` pointers. It can be again safely serialized using `JSON.stringify()`.
+
+This method is synchronous
+
+```javascript
+let schemaDeref = await $RefParser.dereference("my-schema.yaml");
+let schema = $RefParser.rereference(schemaDeref);
+
+// The `schema` object is serializable,
+JSON.stringify(schema, null , 2);
+```
 
 ### `parse(schema, [options], [callback])`
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -98,6 +98,28 @@ declare class $RefParser {
   public static bundle(baseUrl: string, schema: string | $RefParser.JSONSchema, options: $RefParser.Options): Promise<$RefParser.JSONSchema>;
 
   /**
+   * Rereferences all `$ref` pointers in the JSON Schema, replacing each JavaScript circular pointers with its new reference. This results in a schema object that does can contain `$ref` pointers. It can be again safely serialized using `JSON.stringify()`.
+   *
+   * This method is synchronous
+   *
+   * @param schema A JSON Schema object
+   * @param options (optional)
+   * @returns schema A JSON Schema object
+   */
+  public rereference(schema: $RefParser.JSONSchema, options?: $RefParser.Options): $RefParser.JSONSchema;
+
+  /**
+   * Rereferences all `$ref` pointers in the JSON Schema, replacing each JavaScript circular pointers with its new reference. This results in a schema object that does can contain `$ref` pointers. It can be again safely serialized using `JSON.stringify()`.
+   *
+   * This method is synchronous
+   *
+   * @param schema A JSON Schema object
+   * @param options (optional)
+   * @returns schema A JSON Schema object
+   */
+  public static rereference(schema: $RefParser.JSONSchema, options?: $RefParser.Options): $RefParser.JSONSchema;
+
+  /**
    * *This method is used internally by other methods, such as `bundle` and `dereference`. You probably won't need to call this method yourself.*
    *
    * Parses the given JSON Schema file (in JSON or YAML format), and returns it as a JavaScript object. This method `does not` resolve `$ref` pointers or dereference anything. It simply parses one file and returns it.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -102,6 +102,8 @@ declare class $RefParser {
    *
    * This method is synchronous
    *
+   * See https://apitools.dev/json-schema-ref-parser/docs/ref-parser.html#rereferenceschema-options
+   *
    * @param schema A JSON Schema object
    * @param options (optional)
    * @returns schema A JSON Schema object
@@ -112,6 +114,8 @@ declare class $RefParser {
    * Rereferences all `$ref` pointers in the JSON Schema, replacing each JavaScript circular pointers with its new reference. This results in a schema object that does can contain `$ref` pointers. It can be again safely serialized using `JSON.stringify()`.
    *
    * This method is synchronous
+   *
+   * See https://apitools.dev/json-schema-ref-parser/docs/ref-parser.html#rereferenceschema-options
    *
    * @param schema A JSON Schema object
    * @param options (optional)

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ const _parse = require("./parse");
 const normalizeArgs = require("./normalize-args");
 const resolveExternal = require("./resolve-external");
 const _bundle = require("./bundle");
+const _rereference = require("./rereference");
 const _dereference = require("./dereference");
 const url = require("./util/url");
 const { JSONParserError, InvalidPointerError, MissingPointerError, ResolverError, ParserError, UnmatchedParserError, UnmatchedResolverError, isHandledError, JSONParserErrorGroup } = require("./util/errors");
@@ -272,6 +273,30 @@ $RefParser.prototype.dereference = async function dereference (path, schema, opt
   }
   catch (err) {
     return maybe(args.callback, Promise.reject(err));
+  }
+};
+
+$RefParser.rereference = function rereference (schema, options) {
+  let Class = this; // eslint-disable-line consistent-this
+  let instance = new Class();
+  return instance.rereference.apply(instance, arguments);
+};
+
+$RefParser.prototype.rereference = function rereference (schema, options) {
+  let me = this;
+
+  let $ref = this.$refs._add("");
+  $ref.value = schema;
+  $ref.pathType = "http";
+  this.schema = schema;
+
+  try {
+    me.schema = _rereference(me, options);
+    finalize(me);
+    return me.schema;
+  }
+  catch (err) {
+    throw err;
   }
 };
 

--- a/lib/rereference.js
+++ b/lib/rereference.js
@@ -22,20 +22,24 @@ function rereference (parser, options) {
   // definitions creation
   const definitions = parser.schema.definitions || {};
   Object.keys($refPathMap).forEach((pathItem) => {
-    const defPath = pathItem.split("#/")[1];
-    const defPathList = defPath.split("/");
+    // if internal reference
+    if (pathItem.indexOf("#/") !== -1) {
+      const defPath = pathItem.split("#/")[1];
+      const defPathList = defPath.split("/");
 
-    // if not an already present definition
-    if (defPathList.length !== 2 || defPathList[0] !== "definitions") {
-      definitions[defPathList.join("-")] = $refPathMap[pathItem];
+      // if not an already present definition
+      if (defPathList.length !== 2 || defPathList[0] !== "definitions") {
+        definitions[defPathList.join("-")] = $refPathMap[pathItem];
+      }
     }
   });
 
   // crawl to replace circularity by definitions
-  parser.schema = crawl({
+  const updatedSchema = {
     ...parser.schema,
     definitions
-  }, null, "#", options, definitions, Object.values(definitions));
+  };
+  parser.schema = crawl(parser.schema, updatedSchema, null, "#", options, definitions, Object.values(definitions));
 
   return parser.schema;
 }
@@ -91,6 +95,7 @@ function preCrawl (parent, key, pathFromRoot, options, $refPathMap, computedPath
 /**
  * Recursively crawls the given value, and create references fr circular items.
  *
+ * @param {object} originalSchema - The root schema to crawl.
  * @param {object} parent - The object containing the value to crawl. If the value is not an object or array, it will be ignored.
  * @param {string | null} key - The property key of `parent` to be crawled
  * @param {string} pathFromRoot - The path of the property being crawled, from the schema root
@@ -98,7 +103,7 @@ function preCrawl (parent, key, pathFromRoot, options, $refPathMap, computedPath
  * @param {object.<string, *>} definitions - pointer to root definitions of the schema
  * @param {*} definitionValues - all the root definitions values
  */
-function crawl (parent, key, pathFromRoot, options, definitions, definitionValues) {
+function crawl (originalSchema, parent, key, pathFromRoot, options, definitions, definitionValues) {
   let obj = key === null ? parent : parent[key];
 
   if (obj && typeof obj === "object" && !ArrayBuffer.isView(obj)) {
@@ -106,7 +111,15 @@ function crawl (parent, key, pathFromRoot, options, definitions, definitionValue
       return obj;
     }
     else {
-      if (definitionValues.indexOf(obj) !== -1) {
+      // reference to root schema
+      // check done on original unmodified schema to avoid js pointer break
+      if (obj === originalSchema && pathFromRoot !== "#") {
+        return {
+          $ref: "#"
+        };
+      }
+      // reference to definition
+      else if (definitionValues.indexOf(obj) !== -1) {
         const defPath = "#/definitions/" + Object.keys(definitions).find((pathKey) => {
           return definitions[pathKey] === obj;
         });
@@ -133,7 +146,7 @@ function crawl (parent, key, pathFromRoot, options, definitions, definitionValue
           newObj[keyItem] = value;
         }
         else {
-          newObj[keyItem] = crawl(obj, keyItem, keyPathFromRoot, options, definitions, definitionValues);
+          newObj[keyItem] = crawl(originalSchema, obj, keyItem, keyPathFromRoot, options, definitions, definitionValues);
         }
       }
 

--- a/lib/rereference.js
+++ b/lib/rereference.js
@@ -1,0 +1,162 @@
+"use strict";
+
+const $Ref = require("./ref");
+const Pointer = require("./pointer");
+
+module.exports = rereference;
+
+/**
+ * Rereference all circular items
+ * only has *internal* references, not any *external* references.
+ * This method returns a new JSON schema object, adding new references.
+ *
+ * @param {$RefParser} parser
+ * @param {$RefParserOptions} options
+ */
+function rereference (parser, options) {
+  const $refPathMap = {};
+
+  // pre-crawl to detect circularity
+  preCrawl(parser.schema, null, "#", options, $refPathMap);
+
+  // definitions creation
+  const definitions = parser.schema.definitions || {};
+  Object.keys($refPathMap).forEach((pathItem) => {
+    const defPath = pathItem.split("#/")[1];
+    const defPathList = defPath.split("/");
+
+    // if not an already present definition
+    if (defPathList.length !== 2 || defPathList[0] !== "definitions") {
+      definitions[defPathList.join("-")] = $refPathMap[pathItem];
+    }
+  });
+
+  // crawl to replace circularity by definitions
+  parser.schema = crawl({
+    ...parser.schema,
+    definitions
+  }, null, "#", options, definitions, Object.values(definitions));
+
+  return parser.schema;
+}
+
+
+/**
+ * Recursively crawls the given value, and return circular items.
+ *
+ * @param {object} parent - The object containing the value to crawl. If the value is not an object or array, it will be ignored.
+ * @param {string | null} key - The property key of `parent` to be crawled
+ * @param {string} pathFromRoot - The path of the property being crawled, from the schema root
+ * @param {$RefParserOptions} options
+ * @param {object.<string, *>} $refPathMap
+ * @param {object.<string, *>} computedPathMap
+ */
+function preCrawl (parent, key, pathFromRoot, options, $refPathMap, computedPathMap = {}) {
+  let obj = key === null ? parent : parent[key];
+
+  if (obj && typeof obj === "object" && !ArrayBuffer.isView(obj)) {
+    const allObj = Object.values(computedPathMap);
+    if ($Ref.isAllowed$Ref(obj)) {
+      // nothing to do
+    }
+    else if (allObj.indexOf(obj) !== -1) {
+      const refPath = Object.keys(computedPathMap).find((pathKey) => {
+        return computedPathMap[pathKey] === obj;
+      });
+      if (!$refPathMap[refPath]) {
+        $refPathMap[refPath] = obj;
+      }
+    }
+    else {
+      computedPathMap[pathFromRoot] = obj;
+
+      let keys = Object.keys(obj).sort(sortKeys);
+
+      for (let keyItem of keys) {
+        let keyPathFromRoot = Pointer.join(pathFromRoot, keyItem);
+        let value = obj[keyItem];
+
+        if (keyItem === "default" || $Ref.isAllowed$Ref(value)) {
+          // nothing to do
+        }
+        else {
+          preCrawl(obj, keyItem, keyPathFromRoot, options, $refPathMap, computedPathMap);
+        }
+      }
+    }
+  }
+}
+
+
+/**
+ * Recursively crawls the given value, and create references fr circular items.
+ *
+ * @param {object} parent - The object containing the value to crawl. If the value is not an object or array, it will be ignored.
+ * @param {string | null} key - The property key of `parent` to be crawled
+ * @param {string} pathFromRoot - The path of the property being crawled, from the schema root
+ * @param {$RefParserOptions} options
+ * @param {object.<string, *>} definitions - pointer to root definitions of the schema
+ * @param {*} definitionValues - all the root definitions values
+ */
+function crawl (parent, key, pathFromRoot, options, definitions, definitionValues) {
+  let obj = key === null ? parent : parent[key];
+
+  if (obj && typeof obj === "object" && !ArrayBuffer.isView(obj)) {
+    if ($Ref.isAllowed$Ref(obj)) {
+      return obj;
+    }
+    else {
+      if (definitionValues.indexOf(obj) !== -1) {
+        const defPath = "#/definitions/" + Object.keys(definitions).find((pathKey) => {
+          return definitions[pathKey] === obj;
+        });
+
+        if (pathFromRoot !== defPath) {
+          return {
+            $ref: defPath
+          };
+        }
+      }
+
+      // Crawl the object in a specific order that's optimized for bundling.
+      // This is important because it determines how `pathFromRoot` gets built,
+      // which later determines which keys get dereferenced and which ones get remapped
+      // const nextPathMap = { ...pathMap, [path]: obj };
+      let keys = Object.keys(obj).sort(sortKeys);
+
+      const newObj = Array.isArray(obj) ? [] : {};
+      for (let keyItem of keys) {
+        let keyPathFromRoot = Pointer.join(pathFromRoot, keyItem);
+        let value = obj[keyItem];
+
+        if (keyItem === "default" || $Ref.isAllowed$Ref(value)) {
+          newObj[keyItem] = value;
+        }
+        else {
+          newObj[keyItem] = crawl(obj, keyItem, keyPathFromRoot, options, definitions, definitionValues);
+        }
+      }
+
+      return newObj;
+    }
+  }
+
+  return obj;
+}
+
+
+const sortKeys = (a, b) => {
+  // Most people will expect references to be bundled into the the "definitions" property,
+  // so we always crawl that property first, if it exists.
+  if (a === "definitions") {
+    return -1;
+  }
+  else if (b === "definitions") {
+    return 1;
+  }
+  else {
+    // Otherwise, crawl the keys based on their length.
+    // This produces the shortest possible bundled references
+    return a.length - b.length;
+  }
+};

--- a/lib/rereference.js
+++ b/lib/rereference.js
@@ -72,7 +72,13 @@ function preCrawl (parent, key, pathFromRoot, options, $refPathMap, computedPath
       }
     }
     else {
-      computedPathMap[pathFromRoot] = obj;
+      // check if key is not a reserved property ot type object
+      // avoid references on properties, dependencies, ...
+      // this case can appear when dereference creates a pointer to an object, but because of a different description spread it in another object
+      const reservedKeys = ["properties", "patternProperties", "dependencies", "definitions"];
+      if (reservedKeys.indexOf(key) === -1 && !Array.isArray(obj)) {
+        computedPathMap[pathFromRoot] = obj;
+      }
 
       let keys = Object.keys(obj).sort(sortKeys);
 

--- a/test/specs/circular/circular.spec.js
+++ b/test/specs/circular/circular.spec.js
@@ -6,6 +6,7 @@ const helper = require("../../utils/helper");
 const path = require("../../utils/path");
 const parsedSchema = require("./parsed");
 const dereferencedSchema = require("./dereferenced");
+const rereferencedSchema = require("./rereferenced");
 
 describe("Schema with circular (recursive) $refs", () => {
   describe("$ref to self", () => {
@@ -71,6 +72,16 @@ describe("Schema with circular (recursive) $refs", () => {
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+    });
+
+    it("should rereference successfully", async () => {
+      let parser = new $RefParser();
+      const schemaDeref = await parser.dereference(path.rel("specs/circular/circular-self.yaml"));
+      parser = new $RefParser();
+      const schema = await parser.rereference(schemaDeref);
+
+      expect(schema).to.equal(parser.schema);
+      expect(schema).to.deep.equal(rereferencedSchema.self);
     });
   });
 
@@ -140,6 +151,16 @@ describe("Schema with circular (recursive) $refs", () => {
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+    });
+
+    it("should rereference successfully", async () => {
+      let parser = new $RefParser();
+      const schemaDeref = await parser.dereference(path.rel("specs/circular/circular-ancestor.yaml"));
+      parser = new $RefParser();
+      const schema = await parser.rereference(schemaDeref);
+
+      expect(schema).to.equal(parser.schema);
+      expect(schema).to.deep.equal(rereferencedSchema.ancestor);
     });
   });
 
@@ -212,6 +233,16 @@ describe("Schema with circular (recursive) $refs", () => {
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
     });
+
+    it("should rereference successfully", async () => {
+      let parser = new $RefParser();
+      const schemaDeref = await parser.dereference(path.rel("specs/circular/circular-indirect.yaml"));
+      parser = new $RefParser();
+      const schema = await parser.rereference(schemaDeref);
+
+      expect(schema).to.equal(parser.schema);
+      expect(schema).to.deep.equal(rereferencedSchema.indirect);
+    });
   });
 
   describe("indirect circular and ancestor $refs", () => {
@@ -282,6 +313,16 @@ describe("Schema with circular (recursive) $refs", () => {
       // The "circular" flag should NOT be set
       // (it only gets set by `dereference`)
       expect(parser.$refs.circular).to.equal(false);
+    });
+
+    it("should rereference successfully", async () => {
+      let parser = new $RefParser();
+      const schemaDeref = await parser.dereference(path.rel("specs/circular/circular-indirect-ancestor.yaml"));
+      parser = new $RefParser();
+      const schema = await parser.rereference(schemaDeref);
+
+      expect(schema).to.equal(parser.schema);
+      expect(schema).to.deep.equal(rereferencedSchema.indirectAncestor);
     });
   });
 

--- a/test/specs/circular/rereferenced.js
+++ b/test/specs/circular/rereferenced.js
@@ -1,0 +1,204 @@
+"use strict";
+
+module.exports =
+{
+  self: {
+    definitions: {
+      pet: {
+        type: "object",
+        title: "pet",
+        properties: {
+          age: {
+            type: "number"
+          },
+          name: {
+            type: "string"
+          },
+          species: {
+            type: "string",
+            enum: [
+              "cat",
+              "dog",
+              "bird",
+              "fish"
+            ]
+          }
+        }
+      },
+      child: {
+        type: "object",
+        title: "child",
+        properties: {
+          pet: {
+            $ref: "#/definitions/pet"
+          },
+          name: {
+            type: "string"
+          }
+        }
+      },
+      thing: {
+        $ref: "#/definitions/thing"
+      }
+    }
+  },
+
+  ancestor: {
+    definitions: {
+      pet: {
+        type: "object",
+        title: "pet",
+        properties: {
+          age: {
+            type: "number"
+          },
+          name: {
+            type: "string"
+          },
+          species: {
+            type: "string",
+            enum: [
+              "cat",
+              "dog",
+              "bird",
+              "fish"
+            ]
+          }
+        }
+      },
+      person: {
+        title: "person",
+        properties: {
+          pet: {
+            $ref: "#/definitions/pet"
+          },
+          age: {
+            type: "number"
+          },
+          name: {
+            type: "string"
+          },
+          spouse: {
+            $ref: "#/definitions/person"
+          }
+        }
+      }
+    }
+  },
+
+  indirect: {
+    definitions: {
+      pet: {
+        type: "object",
+        title: "pet",
+        properties: {
+          age: {
+            type: "number"
+          },
+          name: {
+            type: "string"
+          },
+          species: {
+            type: "string",
+            enum: [
+              "cat",
+              "dog",
+              "bird",
+              "fish"
+            ]
+          }
+        }
+      },
+      child: {
+        title: "child",
+        properties: {
+          pet: {
+            $ref: "#/definitions/pet"
+          },
+          name: {
+            type: "string"
+          },
+          parents: {
+            type: "array",
+            items: {
+              $ref: "#/definitions/parent"
+            }
+          }
+        }
+      },
+      parent: {
+        title: "parent",
+        properties: {
+          name: {
+            type: "string"
+          },
+          children: {
+            type: "array",
+            items: {
+              $ref: "#/definitions/child"
+            }
+          }
+        }
+      },
+      "definitions-child-properties-parents-items": {
+        $ref: "#/definitions/parent"
+      }
+    }
+  },
+
+  indirectAncestor: {
+    definitions: {
+      pet: {
+        type: "object",
+        title: "pet",
+        properties: {
+          age: {
+            type: "number"
+          },
+          name: {
+            type: "string"
+          },
+          species: {
+            type: "string",
+            enum: [
+              "cat",
+              "dog",
+              "bird",
+              "fish"
+            ]
+          }
+        }
+      },
+      child: {
+        title: "child",
+        properties: {
+          pet: {
+            $ref: "#/definitions/pet"
+          },
+          name: {
+            type: "string"
+          },
+          children: {
+            type: "array",
+            items: {
+              $ref: "#/definitions/child"
+            },
+            description: "children"
+          }
+        }
+      },
+      parent: {
+        title: "parent",
+        properties: {
+          name: {
+            type: "string"
+          },
+          child: {
+            $ref: "#/definitions/child"
+          }
+        }
+      }
+    }
+  }
+
+};

--- a/test/specs/exports.spec.js
+++ b/test/specs/exports.spec.js
@@ -24,6 +24,8 @@ describe("json-schema-ref-parser package exports", () => {
     expect(parser.prototype.resolve).to.be.a("function").with.property("name", "resolve");
     expect(parser.dereference).to.be.a("function").with.property("name", "dereference");
     expect(parser.prototype.dereference).to.be.a("function").with.property("name", "dereference");
+    expect(parser.rereference).to.be.a("function").with.property("name", "rereference");
+    expect(parser.prototype.rereference).to.be.a("function").with.property("name", "rereference");
     expect(parser.bundle).to.be.a("function").with.property("name", "bundle");
     expect(parser.prototype.bundle).to.be.a("function").with.property("name", "bundle");
     return true;
@@ -78,6 +80,7 @@ describe("json-schema-ref-parser package exports", () => {
       "parse",
       "resolve",
       "dereference",
+      "rereference",
       "bundle",
       "JSONParserError",
       "InvalidPointerError",


### PR DESCRIPTION
**Bundle** method only internalise all the external references inside internal references
A **dereferenced** schema cannot be serialised after being bundled

**Rereference** is here created to exactly do the the opposite of **dereference**: replacing each JavaScript circular pointers with its new reference.
Another advantage is this method is also totally synchronous

It can be used in conjunction to **bundle** method if you want also to internalise external refs

