### PR TITLE
external refs: keep track of original paths during resolve

### DIFF
--- a/lib/resolve-external.js
+++ b/lib/resolve-external.js
@@ -94,12 +94,17 @@ function crawl (obj, path, $refs, options, seen) {
 async function resolve$Ref ($ref, path, $refs, options) {
   // console.log('Resolving $ref pointer "%s" at %s', $ref.$ref, path);
 
+  let originalPath = $ref.$ref;
   let resolvedPath = url.resolve(path, $ref.$ref);
   let withoutHash = url.stripHash(resolvedPath);
 
   // Do we already have this $ref?
   $ref = $refs._$refs[withoutHash];
   if ($ref) {
+    // Keep track of originalPaths
+    $ref.originalPaths = $ref.originalPaths || new Set();
+    $ref.originalPaths.add(originalPath);
+
     // We've already parsed this $ref, so use the existing value
     return Promise.resolve($ref.value);
   }


### PR DESCRIPTION
Right now the library is “loosing” the original value
information from the `$ref` entry in case of we are resolving relative
file paths.

However, it can be a useful information to keep. This PR is thus trying
to keep a `Set` containing all original paths when resolving external
$ref pointers.