### PR TITLE
refs: resolve file system path correctly with encoded values

### DIFF
--- a/lib/refs.js
+++ b/lib/refs.js
@@ -148,6 +148,9 @@ $Refs.prototype._resolve = function (path, pathFromRoot, options) {
   let absPath = url.resolve(this._root$Ref.path, path);
   let withoutHash = url.stripHash(absPath);
   let $ref = this._$refs[withoutHash];
+  if (url.isFileSystemPath(withoutHash)) {
+    $ref = this._$refs[url.fromFileSystemPath(withoutHash)];
+  }
 
   if (!$ref) {
     throw ono(`Error resolving $ref pointer "${path}". \n"${withoutHash}" not found.`);


### PR DESCRIPTION
The internal `_$refs` object stores all references path with an URL
encoded value.

However when using the public API of the $refs object
most user will, most probably, expect to pass the decoded file
path to all public methods (https://github.com/APIDevTools/json-schema-ref-parser/blob/master/docs/refs.md#methods)

This commit makes sure to search for URL encoded path value when the
path is a file system path.