### PR TITLE
fix: root level reference internally do not resolved 

### DIFF
--- a/test/specs/root-internal/bundled.js
+++ b/test/specs/root-internal/bundled.js
@@ -1,0 +1,19 @@
+"use strict";
+
+module.exports =
+{
+  title: "name",
+  required: [
+    "first",
+    "last"
+  ],
+  type: "object",
+  properties: {
+    last: {
+      type: "string"
+    },
+    first: {
+      type: "string"
+    }
+  },
+};

--- a/test/specs/root-internal/dereferenced.js
+++ b/test/specs/root-internal/dereferenced.js
@@ -1,0 +1,19 @@
+"use strict";
+
+module.exports =
+{
+  title: "name",
+  required: [
+    "first",
+    "last"
+  ],
+  type: "object",
+  properties: {
+    last: {
+      type: "string"
+    },
+    first: {
+      type: "string"
+    }
+  },
+};

--- a/test/specs/root-internal/parsed.js
+++ b/test/specs/root-internal/parsed.js
@@ -1,0 +1,26 @@
+"use strict";
+
+module.exports =
+{
+  schema: {
+    definitions: {
+      name: {
+        title: "name",
+        required: [
+          "first",
+          "last"
+        ],
+        type: "object",
+        properties: {
+          last: {
+            $ref: "#/definitions/name/properties/first"
+          },
+          first: {
+            type: "string"
+          }
+        },
+      }
+    },
+    $ref: "#/definitions/name"
+  }
+};

--- a/test/specs/root-internal/root-internal.spec.js
+++ b/test/specs/root-internal/root-internal.spec.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const { expect } = require("chai");
+const $RefParser = require("../../..");
+const helper = require("../../utils/helper");
+const path = require("../../utils/path");
+const parsedSchema = require("./parsed");
+const dereferencedSchema = require("./dereferenced");
+const bundledSchema = require("./bundled");
+
+describe("Schema with a top-level internal (root) $ref", () => {
+  it("should parse successfully", async () => {
+    let parser = new $RefParser();
+    const schema = await parser.parse(path.rel("specs/root-internal/root-internal.yaml"));
+    expect(schema).to.equal(parser.schema);
+    expect(schema).to.deep.equal(parsedSchema.schema);
+    expect(parser.$refs.paths()).to.deep.equal([path.abs("specs/root-internal/root-internal.yaml")]);
+  });
+
+  it("should resolve successfully", helper.testResolve(
+    path.rel("specs/root-internal/root-internal.yaml"),
+    path.abs("specs/root-internal/root-internal.yaml"), parsedSchema.schema
+  ));
+
+  it("should dereference successfully", async () => {
+    let parser = new $RefParser();
+    const schema = await parser.dereference(path.rel("specs/root-internal/root-internal.yaml"));
+    expect(schema).to.equal(parser.schema);
+    expect(schema).to.deep.equal(dereferencedSchema);
+    // Reference equality
+    expect(schema.properties.first).to.equal(schema.properties.last);
+    // The "circular" flag should NOT be set
+    expect(parser.$refs.circular).to.equal(false);
+  });
+
+  it("should bundle successfully", async () => {
+    let parser = new $RefParser();
+    const schema = await parser.bundle(path.rel("specs/root-internal/root-internal.yaml"));
+    expect(schema).to.equal(parser.schema);
+    expect(schema).to.deep.equal(bundledSchema);
+  });
+});

--- a/test/specs/root-internal/root-internal.yaml
+++ b/test/specs/root-internal/root-internal.yaml
@@ -1,0 +1,13 @@
+definitions: 
+  name: 
+    title: name
+    type: object
+    required:
+      - first
+      - last
+    properties:
+      first:
+        type: string
+      last:
+        $ref: "#/definitions/name/properties/first"
+$ref: "#/definitions/name"


### PR DESCRIPTION
This PR addresses the issue where root level references to internal schema definitions are not resolved accurately.

Fixes https://github.com/APIDevTools/json-schema-ref-parser/issues/201