### PR TITLE
fix: force YAML loading to confirm to JSON-compatible types

### DIFF
--- a/lib/parsers/yaml.js
+++ b/lib/parsers/yaml.js
@@ -2,6 +2,7 @@
 
 const { ParserError } = require("../util/errors");
 const yaml = require("js-yaml");
+const { JSON_SCHEMA } = require("js-yaml");
 
 module.exports = {
   /**
@@ -45,7 +46,7 @@ module.exports = {
 
     if (typeof data === "string") {
       try {
-        return yaml.load(data);
+        return yaml.load(data, { schema: JSON_SCHEMA });
       }
       catch (e) {
         throw new ParserError(e.message, file.url);

--- a/test/specs/date-strings/date-strings.spec.js
+++ b/test/specs/date-strings/date-strings.spec.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const { expect } = require("chai");
+const $RefParser = require("../../..");
+const helper = require("../../utils/helper");
+const path = require("../../utils/path");
+const parsedSchema = require("./parsed");
+
+describe("Schema with date strings", () => {
+  it("should parse successfully", async () => {
+    let parser = new $RefParser();
+    const schema = await parser.parse(path.rel("specs/date-strings/date-strings.yaml"));
+    expect(schema).to.equal(parser.schema);
+    expect(schema).to.deep.equal(parsedSchema.schema);
+    expect(parser.$refs.paths()).to.deep.equal([path.abs("specs/date-strings/date-strings.yaml")]);
+  });
+
+  it("should resolve successfully", helper.testResolve(
+    path.rel("specs/date-strings/date-strings.yaml"),
+    path.abs("specs/date-strings/date-strings.yaml"), parsedSchema.schema,
+  ));
+});

--- a/test/specs/date-strings/date-strings.yaml
+++ b/test/specs/date-strings/date-strings.yaml
@@ -1,0 +1,6 @@
+title: Date Strings
+type: object
+properties:
+  name:
+    description: 2015-04-22T10:03:19.323-07:00
+    type: string

--- a/test/specs/date-strings/parsed.js
+++ b/test/specs/date-strings/parsed.js
@@ -1,0 +1,14 @@
+"use strict";
+
+module.exports = {
+  schema: {
+    title: "Date Strings",
+    type: "object",
+    properties: {
+      name: {
+        description: "2015-04-22T10:03:19.323-07:00",
+        type: "string"
+      }
+    }
+  }
+};


### PR DESCRIPTION
While investigating some `@apidevtools/swagger-parser` quirks I discovered that loading a YAML file that contains a date-like string causes that date to be converted into a `Date` object, causing the API definition to fail validation.

This updates the usage of `js-yaml` to ensure that all YAML content conforms to JSON-compatible types by way of its `schema` option ([docs here](https://github.com/nodeca/js-yaml#load-string---options-)). 