### PR TITLE
Fix tests (by fixing error paths generally) when run in paths with spaces

### DIFF
--- a/lib/pointer.js
+++ b/lib/pointer.js
@@ -91,7 +91,7 @@ Pointer.prototype.resolve = function (obj, options, pathFromRoot) {
     let token = tokens[i];
     if (this.value[token] === undefined || this.value[token] === null) {
       this.value = null;
-      throw new MissingPointerError(token, this.originalPath);
+      throw new MissingPointerError(token, decodeURI(this.originalPath));
     }
     else {
       this.value = this.value[token];

--- a/lib/ref.js
+++ b/lib/ref.js
@@ -135,7 +135,7 @@ $Ref.prototype.resolve = function (path, options, friendlyPath, pathFromRoot) {
     if (err instanceof InvalidPointerError) {
       // this is a special case - InvalidPointerError is thrown when dereferencing external file,
       // but the issue is caused by the source file that referenced the file that undergoes dereferencing
-      err.source = stripHash(pathFromRoot);
+      err.source = decodeURI(stripHash(pathFromRoot));
     }
 
     this.addError(err);

--- a/lib/resolve-external.js
+++ b/lib/resolve-external.js
@@ -120,7 +120,7 @@ async function resolve$Ref ($ref, path, $refs, options) {
     }
 
     if ($refs._$refs[withoutHash]) {
-      err.source = url.stripHash(path);
+      err.source = decodeURI(url.stripHash(path));
       err.path = url.safePointerToPath(url.getHash(path));
     }
 

--- a/test/specs/error-source/error-source.spec.js
+++ b/test/specs/error-source/error-source.spec.js
@@ -8,7 +8,6 @@ const { expect } = chai;
 const $RefParser = require("../../..");
 const helper = require("../../utils/helper");
 const path = require("../../utils/path");
-const { host } = require("@jsdevtools/host-environment");
 const { InvalidPointerError, ResolverError, MissingPointerError } = require("../../../lib/util/errors");
 
 
@@ -30,12 +29,6 @@ describe("Report correct error source and path for", () => {
       ]);
     }
   });
-
-  if (host.node && host.os.windows && path.cwd().includes(" ")) {
-    // The tests below don't support Windows file paths that contain spaces.
-    // TODO: Fix the tests below, rather than skipping them
-    return;
-  }
 
   it("schema with a local reference pointing at property with broken external reference", async () => {
     const parser = new $RefParser();


### PR DESCRIPTION
Previously, on Windows and Linux (comment here was incorrect) these tests failed if the path contained spaces, because the err.source property used %20 instead of a literal space. This happens because internal URL-encoded path representations are attached directly to the error, instead of the actual path.

While this was commented out as a test error, this is actually a real bug - errors referencing paths all contained unexpectedly encoded strings.

(Pro-tip: store all your code in a local folder with spaces, and it's super easy to catch these issues before they become actual bugs that seriously break things. Easy to do in CI too!)

This change ensures that the path representations are at least decoded correctly before any errors are thrown, so that clear path strings are returned.

It would be possible to go further and use `url.toFileSystemPath` to fully transform the URL-formatted path into a standard platform-specific filesystem path, but that's a bigger change, we could be a breaking change for some use cases, e.g. because it would change from unix to Windows paths on Windows.