### PR TITLE
Allow excluding certain paths from dereferencing

### DIFF
--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -41,8 +41,10 @@ function crawl (obj, path, pathFromRoot, parents, processedObjects, dereferenced
     circular: false
   };
 
+  let isExcludedPath = options.dereference.excludedPathMatcher;
+
   if (options.dereference.circular === "ignore" || !processedObjects.has(obj)) {
-    if (obj && typeof obj === "object" && !ArrayBuffer.isView(obj)) {
+    if (obj && typeof obj === "object" && !ArrayBuffer.isView(obj) && !isExcludedPath(pathFromRoot)) {
       parents.add(obj);
       processedObjects.add(obj);
 
@@ -55,6 +57,9 @@ function crawl (obj, path, pathFromRoot, parents, processedObjects, dereferenced
         for (const key of Object.keys(obj)) {
           let keyPath = Pointer.join(path, key);
           let keyPathFromRoot = Pointer.join(pathFromRoot, key);
+
+          if (isExcludedPath(keyPathFromRoot)) continue;
+
           let value = obj[key];
           let circular = false;
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -73,7 +73,16 @@ $RefParserOptions.defaults = {
      *
      * @type {boolean|string}
      */
-    circular: true
+    circular: true,
+
+    /**
+     * A function, called for each path, which can return true to stop this path and all
+     * subpaths from being dereferenced further. This is useful in schemas where some
+     * subpaths contain literal $ref keys that should not be dereferenced.
+     *
+     * @type {function}
+     */
+    excludedPathMatcher: () => false
   },
 };
 

--- a/test/specs/ref-in-excluded-path/dereferenced.js
+++ b/test/specs/ref-in-excluded-path/dereferenced.js
@@ -1,0 +1,110 @@
+"use strict";
+
+module.exports = {
+  "components": {
+    "examples": {
+      "confirmation-failure": {
+        "value": {
+          "$ref": "#/literal-component-example"
+        }
+      },
+      "confirmation-success": {
+        "value": {
+          "abc": "def"
+        }
+      },
+      "query-example": {
+        "value": "abc"
+      }
+    },
+    "parameters": {
+      "a": {
+        "example": {
+          "$ref": "#/literal-param-component-example"
+        }
+      },
+      "b": {
+        "examples": {
+          "example1": {
+            "value": {
+              "$ref": "#/literal-param-component-examples1"
+            }
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/x/{id}": {
+      "parameters": [
+        {
+          "example": 123,
+          "in": "path",
+          "name": "id"
+        },
+        {
+          "examples": {
+            "e1": {
+              "value": {
+                "$ref": "#/literal-h1"
+              }
+            }
+          },
+          "in": "header",
+          "name": "h1"
+        },
+        {
+          "example": {
+            "$ref": "#/literal-q1"
+          },
+          "in": "query",
+          "name": "q1"
+        },
+        {
+          "examples": {
+            "q2": {
+              "value": "abc"
+            }
+          },
+          "in": "query",
+          "name": "q2"
+        }
+      ],
+      "responses": {
+        "200": {
+          "content": {
+            "application/json": {
+              "examples": {
+                "confirmation-failure": {
+                  "value": {
+                    "$ref": "#/literal-component-example"
+                  }
+                },
+                "confirmation-in-progress": {
+                  "summary": "In progress response",
+                  "value": {
+                    "$ref": "#/abc"
+                  }
+                },
+                "confirmation-success": {
+                  "value": {
+                    "abc": "def"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "400": {
+          "content": {
+            "application/json": {
+              "example": {
+                "$ref": "#/literal-example"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};

--- a/test/specs/ref-in-excluded-path/ref-in-excluded-path.spec.js
+++ b/test/specs/ref-in-excluded-path/ref-in-excluded-path.spec.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const { expect } = require("chai");
+const $RefParser = require("../../..");
+const path = require("../../utils/path");
+const dereferencedSchema = require("./dereferenced");
+
+describe("Schema with literal $refs in examples", () => {
+  it("should exclude the given paths from dereferencing", async () => {
+    let parser = new $RefParser();
+    const schema = await parser.dereference(path.rel("specs/ref-in-excluded-path/ref-in-excluded-path.yaml"), {
+      dereference: {
+        excludedPathMatcher: (path) => {
+          return /\/example(\/|$|s\/[^\/]+\/value(\/|$))/.test(path);
+        }
+      }
+    });
+    expect(schema).to.equal(parser.schema);
+    expect(schema).to.deep.equal(dereferencedSchema);
+  });
+});

--- a/test/specs/ref-in-excluded-path/ref-in-excluded-path.yaml
+++ b/test/specs/ref-in-excluded-path/ref-in-excluded-path.yaml
@@ -1,0 +1,60 @@
+# Minimal parts of an OpenAPI 3.1.0 document, including various examples that should be literal:
+paths:
+  '/x/{id}':
+    parameters:
+      - name: id
+        in: path
+        example:
+          123
+      - name: h1
+        in: header
+        examples:
+          e1:
+            value: # Literal value
+              $ref: '#/literal-h1'
+      - name: q1
+        in: query
+        example:
+          $ref: '#/literal-q1'
+      - name: q2
+        in: query
+        examples:
+          q2:
+            $ref: '#/components/examples/query-example'
+    responses:
+      '200':
+        content:
+          application/json:
+            examples:
+              confirmation-success: # Real ref
+                $ref: '#/components/examples/confirmation-success'
+              confirmation-in-progress:
+                summary: In progress response
+                value: # Literal ref! The $ref should not be dereferenced
+                  $ref: '#/abc'
+              confirmation-failure: # Real ref to example with literal $ref
+                $ref: '#/components/examples/confirmation-failure'
+      '400':
+        content:
+          application/json:
+            example:
+              $ref: '#/literal-example'
+components:
+  examples:
+    query-example:
+      value: abc
+    confirmation-success:
+      value:
+        abc: def
+    confirmation-failure:
+      value: # Literal value! The $ref should not be dereferenced
+        $ref: '#/literal-component-example'
+  parameters:
+    a:
+      example:
+        $ref: '#/literal-param-component-example'
+    b:
+      examples:
+        example1:
+          value:
+            $ref: '#/literal-param-component-examples1'


### PR DESCRIPTION
This is the first step towards fixing https://github.com/APIDevTools/swagger-parser/issues/160 and thereby https://github.com/github/rest-api-description/issues/188.

In OpenAPI, examples must be interpreted _literally_. For example, a response could include this `examples` field to illustrate a possible HTTP JSON response body:

```json
"examples": {
  "scim-enterprise-group-list": {
    "value": {
      "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:ListResponse"
      ],
      "totalResults": 2,
      "itemsPerPage": 2,
      "startIndex": 1,
      "Resources": [
        {
          "schemas": [
            "urn:ietf:params:scim:schemas:core:2.0:Group"
          ],
          "id": "abcd27f8-a9aa-11ea-8221-f59b2be9cccc",
          "displayName": "octo-org",
          "members": [
            {
              "value": "92b58aaa-a1d6-11ea-8227-b9ce9e023ccc",
              // v Note the $ref here
              "$ref": "https://api.github.com/scim/v2/enterprises/octo-corp/Users/92b58aaa-a1d6-11ea-8227-b9ce9e023ccc",
              "display": "octocat@github.com"
            }
          ]
        }
      ]
    }
  }
}
```

(This is a smaller version of a real example from [GitHub's OpenAPI spec](https://github.com/github/rest-api-description/))

In this case, this is showing an example where a response really will contain a $ref field - it's not a ref to an external resource in the spec, and it shouldn't ever be dereferenced.

The OpenAPI spec on example objects [here](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#exampleObject) describes this as an "Embedded literal example" and [this discussion](https://github.com/OAI/OpenAPI-Specification/issues/1986#issuecomment-519988505) goes into more detail.

The only way to handle cases like this is to allow callers of `dereference` to stop dereferencing at certain points within a schema's structure. This PR adds a `excludedPathsMatcher` dereference option, which allows the caller to provide a callback that can do this.

The example test shows a quick & dirty approach to how the OpenAPI problem could be solved with this new option. It's not rigorous (really it should be checking against a large list of possible paths from the root) but it shows you the general idea and produces the correct result given the example included here.