### PR TITLE
Ability to skip dereferencing inline/internal $ref values #214

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -26,7 +26,8 @@ $RefParser.dereference("my-schema.yaml", {
     http: {
       timeout: 2000,                // 2 second timeout
       withCredentials: true,        // Include auth credentials when resolving HTTP references
-    }
+    },
+    skipInternal: false             // Skip internal/local references while parsing the document
   },
   dereference: {
     circular: false                 // Don't allow circular $refs

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -40,7 +40,7 @@ function crawl (parent, key, path, pathFromRoot, indirections, inventory, $refs,
   let obj = key === null ? parent : parent[key];
 
   if (obj && typeof obj === "object" && !ArrayBuffer.isView(obj)) {
-    if ($Ref.isAllowed$Ref(obj)) {
+    if ($Ref.isAllowed$Ref(obj, options)) {
       inventory$Ref(parent, key, path, pathFromRoot, indirections, inventory, $refs, options);
     }
     else {
@@ -70,7 +70,7 @@ function crawl (parent, key, path, pathFromRoot, indirections, inventory, $refs,
         let keyPathFromRoot = Pointer.join(pathFromRoot, key);
         let value = obj[key];
 
-        if ($Ref.isAllowed$Ref(value)) {
+        if ($Ref.isAllowed$Ref(value, options)) {
           inventory$Ref(obj, key, path, keyPathFromRoot, indirections, inventory, $refs, options);
         }
         else {

--- a/lib/ref.js
+++ b/lib/ref.js
@@ -185,7 +185,7 @@ $Ref.isExternal$Ref = function (value) {
  */
 $Ref.isAllowed$Ref = function (value, options) {
   if ($Ref.is$Ref(value)) {
-    if (value.$ref.substr(0, 2) === "#/" || value.$ref === "#") {
+    if ((value.$ref.substr(0, 2) === "#/" || value.$ref === "#") && (!options || !options.resolve.skipInternal)) {
       // It's a JSON Pointer reference, which is always allowed
       return true;
     }

--- a/test/specs/skip-internal/bundled.js
+++ b/test/specs/skip-internal/bundled.js
@@ -1,0 +1,44 @@
+"use strict";
+
+module.exports =
+{
+  title: "Person",
+  type: "object",
+  required: [
+    "name"
+  ],
+  properties: {
+    name: {
+      title: "name",
+      type: "object",
+      required: [
+        "first",
+        "last"
+      ],
+      properties: {
+        first: {
+          $ref: "#/properties/requiredString"
+        },
+        last: {
+          $ref: "#/properties/requiredString"
+        }
+      }
+    },
+    age: {
+      type: "integer",
+      minimum: 0
+    },
+    gender: {
+      type: "string",
+      enum: [
+        "male",
+        "female"
+      ]
+    },
+    requiredString: {
+      minLength: 1,
+      title: "required string",
+      type: "string"
+    }
+  }
+};

--- a/test/specs/skip-internal/definitions/definitions.json
+++ b/test/specs/skip-internal/definitions/definitions.json
@@ -1,0 +1,13 @@
+{
+  "name": {
+    "$ref": "./name.yaml"
+  },
+  "age": {
+    "type": "integer",
+    "minimum": 0
+  },
+  "gender": {
+    "type": "string",
+    "enum": ["male", "female"]
+  }
+}

--- a/test/specs/skip-internal/definitions/name.yaml
+++ b/test/specs/skip-internal/definitions/name.yaml
@@ -1,0 +1,10 @@
+title: name
+type: object
+required:
+  - first
+  - last
+properties:
+  first:
+    $ref: "#/properties/requiredString"
+  last:
+    $ref: "#/properties/requiredString"

--- a/test/specs/skip-internal/definitions/required-string.yaml
+++ b/test/specs/skip-internal/definitions/required-string.yaml
@@ -1,0 +1,3 @@
+title: required string
+type: string
+minLength: 1

--- a/test/specs/skip-internal/dereferenced.js
+++ b/test/specs/skip-internal/dereferenced.js
@@ -17,10 +17,10 @@ module.exports =
       ],
       properties: {
         first: {
-          "$ref": "#/properties/requiredString"
+          $ref: "#/properties/requiredString"
         },
         last: {
-          "$ref": "#/properties/requiredString"
+          $ref: "#/properties/requiredString"
         }
       }
     },

--- a/test/specs/skip-internal/dereferenced.js
+++ b/test/specs/skip-internal/dereferenced.js
@@ -1,0 +1,44 @@
+"use strict";
+
+module.exports =
+{
+  title: "Person",
+  type: "object",
+  required: [
+    "name"
+  ],
+  properties: {
+    name: {
+      title: "name",
+      type: "object",
+      required: [
+        "first",
+        "last"
+      ],
+      properties: {
+        first: {
+          "$ref": "#/properties/requiredString"
+        },
+        last: {
+          "$ref": "#/properties/requiredString"
+        }
+      }
+    },
+    age: {
+      type: "integer",
+      minimum: 0
+    },
+    gender: {
+      type: "string",
+      enum: [
+        "male",
+        "female"
+      ]
+    },
+    requiredString: {
+      minLength: 1,
+      title: "required string",
+      type: "string"
+    }
+  }
+};

--- a/test/specs/skip-internal/parsed.js
+++ b/test/specs/skip-internal/parsed.js
@@ -1,0 +1,63 @@
+"use strict";
+
+module.exports =
+{
+  schema: {
+    required: [
+      "name"
+    ],
+    type: "object",
+    properties: {
+      gender: {
+        $ref: "definitions/definitions.json#/gender"
+      },
+      age: {
+        $ref: "definitions/definitions.json#/age"
+      },
+      name: {
+        $ref: "definitions/definitions.json#/name"
+      },
+      requiredString: {
+        $ref: "definitions/required-string.yaml"
+      }
+    },
+    title: "Person"
+  },
+
+  definitions: {
+    name: {
+      $ref: "./name.yaml"
+    },
+    age: {
+      type: "integer",
+      minimum: 0
+    },
+    gender: {
+      type: "string",
+      enum: ["male", "female"]
+    }
+  },
+
+  name: {
+    required: [
+      "first",
+      "last"
+    ],
+    type: "object",
+    properties: {
+      last: {
+        $ref: "#/properties/requiredString"
+      },
+      first: {
+        $ref: "#/properties/requiredString"
+      }
+    },
+    title: "name"
+  },
+
+  requiredString: {
+    minLength: 1,
+    type: "string",
+    title: "required string"
+  }
+};

--- a/test/specs/skip-internal/skip-internal.spec.js
+++ b/test/specs/skip-internal/skip-internal.spec.js
@@ -1,0 +1,43 @@
+"use strict";
+
+const { expect } = require("chai");
+const $RefParser = require("../../..");
+const helper = require("../../utils/helper");
+const path = require("../../utils/path");
+const parsedSchema = require("./parsed");
+const dereferencedSchema = require("./dereferenced");
+const bundledSchema = require("./bundled");
+
+describe("Schema with $refs to parts of external files", () => {
+  it("should parse successfully", async () => {
+    let parser = new $RefParser();
+    const schema = await parser.parse(path.rel("specs/skip-internal/skip-internal.yaml"), { resolve: { skipInternal: true } });
+    expect(schema).to.equal(parser.schema);
+    expect(schema).to.deep.equal(parsedSchema.schema);
+    expect(parser.$refs.paths()).to.deep.equal([path.abs("specs/skip-internal/skip-internal.yaml")]);
+  });
+
+  it("should resolve successfully", helper.testResolve(
+    path.rel("specs/skip-internal/skip-internal.yaml"),
+    path.abs("specs/skip-internal/skip-internal.yaml"), parsedSchema.schema,
+    path.abs("specs/skip-internal/definitions/definitions.json"), parsedSchema.definitions,
+    path.abs("specs/skip-internal/definitions/name.yaml"), parsedSchema.name,
+    path.abs("specs/skip-internal/definitions/required-string.yaml"), parsedSchema.requiredString
+  ));
+
+  it("should dereference successfully", async () => {
+    let parser = new $RefParser();
+    const schema = await parser.dereference(path.rel("specs/skip-internal/skip-internal.yaml"), { resolve: { skipInternal: true } });
+    expect(schema).to.equal(parser.schema);
+    expect(schema).to.deep.equal(dereferencedSchema);
+    // The "circular" flag should NOT be set
+    expect(parser.$refs.circular).to.equal(false);
+  });
+
+  it("should bundle successfully", async () => {
+    let parser = new $RefParser();
+    const schema = await parser.bundle(path.rel("specs/skip-internal/skip-internal.yaml"), { resolve: { skipInternal: true } });
+    expect(schema).to.equal(parser.schema);
+    expect(schema).to.deep.equal(bundledSchema);
+  });
+});

--- a/test/specs/skip-internal/skip-internal.spec.js
+++ b/test/specs/skip-internal/skip-internal.spec.js
@@ -11,7 +11,7 @@ const bundledSchema = require("./bundled");
 describe("Schema with $refs to parts of external files", () => {
   it("should parse successfully", async () => {
     let parser = new $RefParser();
-    const schema = await parser.parse(path.rel("specs/skip-internal/skip-internal.yaml"), { resolve: { skipInternal: true } });
+    const schema = await parser.parse(path.rel("specs/skip-internal/skip-internal.yaml"), { resolve: { skipInternal: true }});
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(parsedSchema.schema);
     expect(parser.$refs.paths()).to.deep.equal([path.abs("specs/skip-internal/skip-internal.yaml")]);
@@ -27,7 +27,7 @@ describe("Schema with $refs to parts of external files", () => {
 
   it("should dereference successfully", async () => {
     let parser = new $RefParser();
-    const schema = await parser.dereference(path.rel("specs/skip-internal/skip-internal.yaml"), { resolve: { skipInternal: true } });
+    const schema = await parser.dereference(path.rel("specs/skip-internal/skip-internal.yaml"), { resolve: { skipInternal: true }});
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
     // The "circular" flag should NOT be set
@@ -36,7 +36,7 @@ describe("Schema with $refs to parts of external files", () => {
 
   it("should bundle successfully", async () => {
     let parser = new $RefParser();
-    const schema = await parser.bundle(path.rel("specs/skip-internal/skip-internal.yaml"), { resolve: { skipInternal: true } });
+    const schema = await parser.bundle(path.rel("specs/skip-internal/skip-internal.yaml"), { resolve: { skipInternal: true }});
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(bundledSchema);
   });

--- a/test/specs/skip-internal/skip-internal.yaml
+++ b/test/specs/skip-internal/skip-internal.yaml
@@ -1,0 +1,13 @@
+title: Person
+type: object
+required:
+  - name
+properties:
+  name:
+    $ref: "definitions/definitions.json#/name"
+  age:
+    $ref: "definitions/definitions.json#/age"
+  gender:
+    $ref: "definitions/definitions.json#/gender"
+  requiredString:
+    $ref: "definitions/required-string.yaml"


### PR DESCRIPTION
Add new option to skip the internal references while parsing the document

This pull request fix the issue: https://github.com/APIDevTools/json-schema-ref-parser/issues/214