### PR TITLE
fix: change type of onDereference to non-required

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -246,7 +246,7 @@ declare namespace $RefParser {
        * @argument {string} path The path being dereferenced (ie. the `$ref` string).
        * @argument {JSONSchemaObject} object The JSON-Schema that the `$ref` resolved to.
        */
-      onDereference(path: string, value: JSONSchemaObject): void;
+      onDereference?(path: string, value: JSONSchemaObject): void;
     };
   }
 


### PR DESCRIPTION
The type of onDereference is required, which breaks types in some downstream packages. The code also checks for its existence on L72 of dereference.js so this is fine.