### PR TITLE
Stage changes to release v9.1.2

### DIFF
--- a/.github/workflows/CI-CD.yaml
+++ b/.github/workflows/CI-CD.yaml
@@ -107,7 +107,7 @@ jobs:
 
   release:
     name: Release
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v9'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v9' || github.ref == 'refs/heads/v9.1.x'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:


### PR DESCRIPTION
This PR will configure semantic-release to release a patch version v9.1.2 off the v9 branch, which should revert the breaking change introduced in v9.1.1.

Once this is merged, the release should actually fail with error:

```
EINVALIDNEXTVERSION The release `9.1.1` on branch `v9.1.x` cannot be published as it is out of range.
Based on the releases published on other branches, only versions within the range >=9.1.0 <9.1.1 can be published from branch v9.1.x.
```

The `v9.1.1` tag will need to be moved from the main branch to the `v9.1.x` branch. (This means the git tag will become out of sync with what got released to npm.) Once this tag is moved, rerunning the actions should release `v9.1.2`.

Once this is released, version 9.1.1 will need to be deprecated on npm manually.