### PR TITLE
fix: External refs with overrides

### DIFF
--- a/lib/resolve-external.ts
+++ b/lib/resolve-external.ts
@@ -64,18 +64,19 @@ function crawl(
     seen.add(obj); // Track previously seen objects to avoid infinite recursion
     if ($Ref.isExternal$Ref(obj)) {
       promises.push(resolve$Ref(obj, path, $refs, options));
-    } else {
-      for (const key of Object.keys(obj)) {
-        const keyPath = Pointer.join(path, key);
-        const value = obj[key] as string | JSONSchema | Buffer | undefined;
-
-        if ($Ref.isExternal$Ref(value)) {
-          promises.push(resolve$Ref(value, keyPath, $refs, options));
-        } else {
-          promises = promises.concat(crawl(value, keyPath, $refs, options, seen));
-        }
-      }
     }
+
+    for (const key of Object.keys(obj)) {
+      const keyPath = Pointer.join(path, key);
+      const value = obj[key] as string | JSONSchema | Buffer | undefined;
+
+      if ($Ref.isExternal$Ref(value)) {
+        promises.push(resolve$Ref(value, keyPath, $refs, options));
+      }
+
+      promises = promises.concat(crawl(value, keyPath, $refs, options, seen));
+    }
+
   }
 
   return promises;


### PR DESCRIPTION
The external resolver did not take into account for overrides. E.g take the following example:

```
$ref: 'base.yaml'
id: my_id
settings:
  $ref: 'base_settings.yaml'
  useCache: true
```


This failed to resolve on `$ref: 'base_settings.yaml'`. This is due to to root object passes `$Ref.isExternal$Ref(obj)` and therefore not considering the other child objects. We should still crawl the tree even though the root has a $ref.