### PR TITLE
Convert relative refs when resolving an external schema

### DIFF
--- a/lib/bundle.ts
+++ b/lib/bundle.ts
@@ -110,7 +110,7 @@ function inventory$Ref(
   options: $RefParserOptions,
 ) {
   const $ref = $refKey === null ? $refParent : $refParent[$refKey];
-  const $refPath = url.resolve(path, $ref.$ref);
+  const $refPath = url.resolve(pathFromRoot, $ref.$ref);
   const pointer = $refs._resolve($refPath, pathFromRoot, options);
   if (pointer === null) {
     return;

--- a/lib/util/url.ts
+++ b/lib/util/url.ts
@@ -3,7 +3,7 @@ const isWindows = /^win/.test(globalThis.process ? globalThis.process.platform :
   protocolPattern = /^(\w{2,}):\/\//i,
   jsonPointerSlash = /~1/g,
   jsonPointerTilde = /~0/g;
-import { join } from "path";
+import { join, dirname, relative } from "path";
 
 const projectDir = join(__dirname, "..", "..");
 // RegExp patterns to URL-encode special characters in local filesystem paths
@@ -270,3 +270,22 @@ export function safePointerToPath(pointer: any) {
       return decodeURIComponent(value).replace(jsonPointerSlash, "/").replace(jsonPointerTilde, "~");
     });
 }
+
+/**
+ * Like path.relative(from, to) but for URLs. It will return a relative
+ * URL if it can, otherwise an absolute URL is returned.
+ * @param from
+ * @param to
+ * @returns
+ */
+export function relative(from: string, to: string): string {
+  if (!isFileSystemPath(from) || !isFileSystemPath(to)) {
+    return resolve(from, to);
+  }
+
+  const fromDir = dirname(stripHash(from));
+  const toPath = stripHash(to);
+
+  const result = relative(fromDir, toPath);
+  return result + getHash(to);
+};


### PR DESCRIPTION
Possibly corrects https://github.com/APIDevTools/json-schema-ref-parser/issues/200.

This however causes tests to fail as they’re not expecting the references to be resolved. I’m not sure yet how to fix the tests. I thought I’d wait to see if the fix is valid!