### PR TITLE
fix: lax the windows path conversion if not available

### DIFF
--- a/lib/util/convert-path-to-posix.ts
+++ b/lib/util/convert-path-to-posix.ts
@@ -7,5 +7,5 @@ export default function convertPathToPosix(filePath: string) {
     return filePath;
   }
 
-  return filePath.split(path.win32.sep).join(path.posix.sep);
+  return filePath.split(path?.win32?.sep).join(path.posix.sep);
 }


### PR DESCRIPTION
This allows for path-browerify to be used as a polyfill for ui usage.