### PR TITLE
feat(errors): pointer additional info

### DIFF
--- a/lib/pointer.ts
+++ b/lib/pointer.ts
@@ -95,7 +95,11 @@ class Pointer {
       const token = tokens[i];
       if (this.value[token] === undefined || this.value[token] === null) {
         this.value = null;
-        throw new MissingPointerError(token, decodeURI(this.originalPath));
+        throw new MissingPointerError(
+          token,
+          decodeURI(this.originalPath),
+          `In the following schema: ${JSON.stringify(this.value, null, 2)}`,
+        );
       } else {
         this.value = this.value[token];
       }

--- a/lib/util/errors.ts
+++ b/lib/util/errors.ts
@@ -115,16 +115,21 @@ export class UnmatchedResolverError extends JSONParserError {
 export class MissingPointerError extends JSONParserError {
   code = "EUNMATCHEDRESOLVER" as JSONParserErrorType;
   name = "MissingPointerError";
-  constructor(token: any, path: any) {
-    super(`Token "${token}" does not exist.`, stripHash(path));
+  constructor(token: any, path: any, additionalMessage?: any) {
+    super(`Token "${token}" does not exist.${additionalMessage ? `\n\n${additionalMessage}\n` : ""}`, stripHash(path));
   }
 }
 
 export class InvalidPointerError extends JSONParserError {
   code = "EUNMATCHEDRESOLVER" as JSONParserErrorType;
   name = "InvalidPointerError";
-  constructor(pointer: any, path: any) {
-    super(`Invalid $ref pointer "${pointer}". Pointers must begin with "#/"`, stripHash(path));
+  constructor(pointer: any, path: any, additionalMessage?: any) {
+    super(
+      `Invalid $ref pointer "${pointer}". Pointers must begin with "#/"${
+        additionalMessage ? `\n\n${additionalMessage}\n` : ""
+      }`,
+      stripHash(path),
+    );
   }
 }
 

--- a/test/specs/missing-pointers/missing-pointers.spec.ts
+++ b/test/specs/missing-pointers/missing-pointers.spec.ts
@@ -45,10 +45,11 @@ describe("Schema with missing pointers", () => {
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
         expect(err.message).to.have.string("1 error occurred while reading '");
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
+        expect(err.errors.map(({ message }) => message).join()).toContain('Token "baz" does not exist.');
+        // @ts-expect-error TS(2571): Object is of type 'unknown'.
         expect(err.errors).to.containSubset([
           {
             name: MissingPointerError.name,
-            message: 'Token "baz" does not exist.',
             path: ["foo"],
             // source: message => message.endsWith("/test/") || message.startsWith("http://localhost"),
           },
@@ -78,10 +79,11 @@ describe("Schema with missing pointers", () => {
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
         expect(err.message).to.have.string("1 error occurred while reading '");
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
+        expect(err.errors.map(({ message }) => message).join()).toContain('Token "external" does not exist.');
+        // @ts-expect-error TS(2571): Object is of type 'unknown'.
         expect(err.errors).to.containSubset([
           {
             name: MissingPointerError.name,
-            message: 'Token "external" does not exist.',
             path: ["internal2"],
             source: (message: any) =>
               message.endsWith("missing-pointers/external-from-internal.yaml") ||

--- a/test/specs/refs.spec.ts
+++ b/test/specs/refs.spec.ts
@@ -235,7 +235,7 @@ describe("$Refs object", () => {
       } catch (err) {
         expect(err).to.be.an.instanceOf(Error);
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
-        expect(err.message).to.equal('Token "" does not exist.');
+        expect(err.message).to.contain('Token "" does not exist.');
       }
     });
 
@@ -273,7 +273,7 @@ describe("$Refs object", () => {
       } catch (err) {
         expect(err).to.be.an.instanceOf(Error);
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
-        expect(err.message).to.equal('Token "foo" does not exist.');
+        expect(err.message).to.contain('Token "foo" does not exist.');
       }
     });
   });


### PR DESCRIPTION
# What
Adds some extra string to `MissingPointerError` and `InvalidPointerError`. But only gets used on one place. Which is when the `token` is not found.

```
- Expected
+ Received

  Token "foo" does not exist.
+
+ In the following schema: null
+
```

or

```
- Expected
+ Received

  Token "components" does not exist.
+
+ In the following schema: {
+ type: "string",
  ...
```

# Why
I ended up with an issue where my refs could not get resolved and throwed out an error. However I got mislead and spent some time approaching the problem from the wrong direction.

The problem was completely my fault. However if I saw on which context it tried to resolve refs, I would've found the issue instantly.