### PR TITLE
fix: Enable compilerOptions noImplicitReturns and noUnusedParameters to improve type safety

### DIFF
--- a/lib/bundle.ts
+++ b/lib/bundle.ts
@@ -290,6 +290,7 @@ function findInInventory(inventory: InventoryEntry[], $refParent: any, $refKey: 
       return existingEntry;
     }
   }
+  return undefined
 }
 
 function removeFromInventory(inventory: InventoryEntry[], entry: any) {

--- a/lib/pointer.ts
+++ b/lib/pointer.ts
@@ -284,6 +284,7 @@ function resolveIf$Ref(pointer: any, options: any, pathFromRoot?: any) {
       return true;
     }
   }
+  return undefined
 }
 export default Pointer;
 

--- a/lib/ref.ts
+++ b/lib/ref.ts
@@ -195,6 +195,7 @@ class $Ref<S extends object = JSONSchema, O extends ParserOptions<S> = ParserOpt
         return true;
       }
     }
+    return undefined
   }
 
   /**

--- a/lib/util/plugins.ts
+++ b/lib/util/plugins.ts
@@ -45,6 +45,7 @@ export function sort(plugins: Plugin[]) {
   });
 }
 
+// @ts-ignore
 export interface PluginResult<S extends object = JSONSchema, O extends ParserOptions<S> = ParserOptions<S>> {
   plugin: Plugin;
   result?: string | Buffer | S;

--- a/lib/util/url.ts
+++ b/lib/util/url.ts
@@ -68,6 +68,7 @@ export function getProtocol(path: string | undefined) {
   if (match) {
     return match[1].toLowerCase();
   }
+  return undefined;
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,9 @@
     "resolveJsonModule": true,
     "rootDir": ".",
     "skipLibCheck": true,
-    "strict": true
+    "strict": true,
+    "noImplicitReturns": true,
+    "noUnusedParameters": true
   },
   "compileOnSave": false,
   "exclude": ["node_modules", "dist"],


### PR DESCRIPTION
Hi, we are using your lib inside a typescript project having the following quite common compilerOptions enabled inside out tsconfig.json.

```
    "noImplicitReturns": true,
    "noUnusedParameters": true
```

This PR enabled this settings on your project as well because the code issues hiding in your code are letting our tsc fail as well. To enable it I fixed most of the underlying code issues. I added `@ts-ignore` to the `PluginResult` interface because I was too shy to remove the not used generic parameter `O`.

Thank you