### PR TITLE
chore: Improve DOM-less type exports

### DIFF
--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -25,7 +25,7 @@ export interface HTTPResolverOptions<S extends object = JSONSchema> extends Part
   /**
    * You can specify any HTTP headers that should be sent when downloading files. For example, some servers may require you to set the `Accept` or `Referrer` header.
    */
-  headers?: HeadersInit | null;
+  headers?: RequestInit['headers'] | null;
 
   /**
    * The amount of time (in milliseconds) to wait for a response from the server when downloading files. The default is 5 seconds.


### PR DESCRIPTION
Usage of `HeadersInit` requires either a node-fetch dependency or to include DOM in tsconfig libs for consumer projects. It is not exported as a global type in \@types/node v18 or v20. `RequestInit` is:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/aaf94a0a6431f52c46dab26182f1156d79720d29/types/node/v18/globals.d.ts#L341

Define headers in interface `HTTPResolverOptions<>` via `RequestInit['headers']` which will make it possible to depend on this project without node-fetch.