### PR TITLE
fix: allow `$ref` pointers to point to a `null` value

### DIFF
--- a/lib/pointer.ts
+++ b/lib/pointer.ts
@@ -5,6 +5,8 @@ import * as url from "./util/url.js";
 import { JSONParserError, InvalidPointerError, MissingPointerError, isHandledError } from "./util/errors.js";
 import type { JSONSchema } from "./types";
 
+export const nullSymbol = Symbol('null');
+
 const slashes = /\//g;
 const tildes = /~/g;
 const escapedSlash = /~1/g;
@@ -125,7 +127,9 @@ class Pointer<S extends object = JSONSchema, O extends ParserOptions<S> = Parser
         // actually instead pointing to an existing `null` value then we should use that
         // `null` value.
         if (token in this.value && this.value[token] === null) {
-          this.value = null;
+          // We use a `null` symbol for internal tracking to differntiate between a general `null`
+          // value and our expected `null` value.
+          this.value = nullSymbol;
           continue;
         }
 

--- a/lib/pointer.ts
+++ b/lib/pointer.ts
@@ -121,6 +121,14 @@ class Pointer<S extends object = JSONSchema, O extends ParserOptions<S> = Parser
           continue;
         }
 
+        // If the token we're looking for ended up not containing any slashes but is
+        // actually instead pointing to an existing `null` value then we should use that
+        // `null` value.
+        if (token in this.value && this.value[token] === null) {
+          this.value = null;
+          continue;
+        }
+
         this.value = null;
 
         const path = this.$ref.path || "";

--- a/lib/ref.ts
+++ b/lib/ref.ts
@@ -1,4 +1,4 @@
-import Pointer from "./pointer.js";
+import Pointer, { nullSymbol } from "./pointer.js";
 import type { JSONParserError, MissingPointerError, ParserError, ResolverError } from "./util/errors.js";
 import { InvalidPointerError, isHandledError, normalizeError } from "./util/errors.js";
 import { safePointerToPath, stripHash, getHash } from "./util/url.js";
@@ -119,7 +119,12 @@ class $Ref<S extends object = JSONSchema, O extends ParserOptions<S> = ParserOpt
   resolve(path: string, options?: O, friendlyPath?: string, pathFromRoot?: string) {
     const pointer = new Pointer<S, O>(this, path, friendlyPath);
     try {
-      return pointer.resolve(this.value, options, pathFromRoot);
+      const resolved = pointer.resolve(this.value, options, pathFromRoot);
+      if (resolved.value === nullSymbol) {
+        resolved.value = null;
+      }
+
+      return resolved;
     } catch (err: any) {
       if (!options || !options.continueOnError || !isHandledError(err)) {
         throw err;
@@ -148,6 +153,9 @@ class $Ref<S extends object = JSONSchema, O extends ParserOptions<S> = ParserOpt
   set(path: string, value: any) {
     const pointer = new Pointer(this, path);
     this.value = pointer.set(this.value, value);
+    if (this.value === nullSymbol) {
+      this.value = null;
+    }
   }
 
   /**

--- a/test/specs/dereference-null-ref/dereference-null-ref.spec.ts
+++ b/test/specs/dereference-null-ref/dereference-null-ref.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it } from "vitest";
+import { expect } from "vitest";
+import $RefParser from "../../../lib/index.js";
+import path from "../../utils/path";
+import dereferenced from "./dereferenced.js";
+
+describe("dereferencing a `$ref` that points to a `null` value", () => {
+  it.only("should dereference successfully", async () => {
+    const parser = new $RefParser();
+    const schema = await parser.dereference(path.rel("test/specs/dereference-null-ref/dereference-null-ref.yaml"));
+    expect(schema).to.equal(parser.schema);
+    expect(schema).to.deep.equal(dereferenced);
+  });
+});

--- a/test/specs/dereference-null-ref/dereference-null-ref.spec.ts
+++ b/test/specs/dereference-null-ref/dereference-null-ref.spec.ts
@@ -5,7 +5,7 @@ import path from "../../utils/path";
 import dereferenced from "./dereferenced.js";
 
 describe("dereferencing a `$ref` that points to a `null` value", () => {
-  it.only("should dereference successfully", async () => {
+  it("should dereference successfully", async () => {
     const parser = new $RefParser();
     const schema = await parser.dereference(path.rel("test/specs/dereference-null-ref/dereference-null-ref.yaml"));
     expect(schema).to.equal(parser.schema);

--- a/test/specs/dereference-null-ref/dereference-null-ref.yaml
+++ b/test/specs/dereference-null-ref/dereference-null-ref.yaml
@@ -1,0 +1,8 @@
+components:
+  examples:
+    product:
+      value:
+        data:
+          admission:
+            $ref: "#/components/examples/product/value/data/pas"
+          pas: null

--- a/test/specs/dereference-null-ref/dereferenced.ts
+++ b/test/specs/dereference-null-ref/dereferenced.ts
@@ -1,0 +1,14 @@
+export default {
+  components: {
+    examples: {
+      product: {
+        value: {
+          data: {
+            admission: null,
+            pas: null,
+          },
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
I've run into a curious issue where the following schema throws a `MissingPointerError` exception:

```yaml
components:
  examples:
    product:
      value:
        data:
          admission:
            $ref: "#/components/examples/product/value/data/pas"
          pas: null
```

I'm having a hard time understanding _why_ the `Pointer` class is running this substring lookup for if a token _does_ exist but it's `null`, but because the token we're looking for is the last in the list in this block it never ends up running the `for` loop below this line to look for a substring -- resulting in it falling through to throw a `MissingPointerError`.

https://github.com/APIDevTools/json-schema-ref-parser/blob/5303da99a58089ddaa4ae08f01205ae9df102a67/lib/pointer.ts#L108-L122

I've managed to fix this by doing a secondary "does this token exist and is it null? ok return that." check and that has resolved this problem in the dereferencer but I also don't know if this is the best way to fix this, or if it will have downstream effects (no tests break with it), or would be considered as a breaking change.

Changing line 108 to **only** check `this.value[token] === undefined` also fixes this issue but even though no tests break with that I don't know if it's the right fix.

Looking for guidance here!