### PR TITLE
fix(bundle): don't look for a `$ref` pointer on a null value

### DIFF
--- a/lib/bundle.ts
+++ b/lib/bundle.ts
@@ -101,8 +101,12 @@ function crawl<S extends object = JSONSchema, O extends ParserOptions<S> = Parse
           crawl(obj, key, keyPath, keyPathFromRoot, indirections, inventory, $refs, options);
         }
 
-        if (value["$ref"]) {
-          bundleOptions?.onBundle?.(value["$ref"], obj[key], obj as any, key);          
+        // We need to ensure that we have an object to work with here because we may be crawling
+        // an `examples` schema and `value` may be nullish.
+        if (value && typeof value === "object" && !Array.isArray(value)) {
+          if ("$ref" in value) {
+            bundleOptions?.onBundle?.(value["$ref"], obj[key], obj as any, key);
+          }
         }
       }
     }

--- a/test/specs/bundle-null-value/bundle-null-value-example.yaml
+++ b/test/specs/bundle-null-value/bundle-null-value-example.yaml
@@ -1,0 +1,12 @@
+defintions:
+  Pet:
+    type: object
+    properties:
+      name:
+        type: string
+      breed:
+        type: string
+        enum: [dog, cat]
+    example:
+      name:
+      breed: dog

--- a/test/specs/bundle-null-value/bundle-null-value.spec.ts
+++ b/test/specs/bundle-null-value/bundle-null-value.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it } from "vitest";
+import { expect } from "vitest";
+import $RefParser from "../../../lib/index.js";
+import path from "../../utils/path";
+import dereferencedSchema from "./bundled";
+
+describe("Bundling schema with nullish values", () => {
+  it("should bundle correctly", async () => {
+    const parser = new $RefParser();
+    const schema = path.rel("test/specs/bundle-null-value/bundle-null-value-example.yaml");
+    const bundled = await parser.bundle(schema);
+    expect(bundled).to.deep.equal(dereferencedSchema);
+  });
+});

--- a/test/specs/bundle-null-value/bundled.ts
+++ b/test/specs/bundle-null-value/bundled.ts
@@ -1,0 +1,22 @@
+const bundledSchema = {
+  defintions: {
+    Pet: {
+      example: {
+        breed: "dog",
+        name: null,
+      },
+      properties: {
+        breed: {
+          enum: ["dog", "cat"],
+          type: "string",
+        },
+        name: {
+          type: "string",
+        },
+      },
+      type: "object",
+    },
+  },
+};
+
+export default bundledSchema;


### PR DESCRIPTION
We had some customers of our CLI tool report issues[^1] this morning of sudden crashes when attempting to validate an OpenAPI definition after we published a new release of our OpenAPI parser[^1] that included an upgrade from v13.0.5 to v14.1.0 with the following error:

```
Cannot read properties of null (reading '$ref')
```

We were able to narrow it down to a regression introduced in https://github.com/APIDevTools/json-schema-ref-parser/pull/391 where it looks for a `$ref` pointer to supply to the `onBundle` callback. The problem our customers had, and we were able to reproduce, encountered with this was on nullish schema examples and this work attempting to look for a `$ref` pointer in it:

<img width="676" height="517" alt="Screenshot 2025-07-15 at 3 31 35 PM" src="https://github.com/user-attachments/assets/635bff17-fdfd-4b49-82b0-66b16502aa7a" />

The fix I've submitted here is to just wrap this check in a type assertion to ensure that we're only looking for a `$ref` pointer in an object.

[^1]: https://github.com/readmeio/rdme/issues/1306
[^2]: https://npm.im/@readme/openapi-parser